### PR TITLE
Remove react-svg, refactor stylings

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "react-router-dom": "^4.3.1",
     "react-scripts": "2.1.8",
     "react-sticky": "^6.0.3",
-    "react-svg": "^7.1.0",
     "react-test-renderer": "^16.8.6",
     "react-transition-group": "^2.5.2",
     "reactstrap": "6.5.0",

--- a/src/assets/styles/_custom-variable.scss
+++ b/src/assets/styles/_custom-variable.scss
@@ -2,26 +2,7 @@
 @import '~open-city-design/src/scss/helsinki/fonts';
 @import '~open-city-design/src/scss/helsinki/mixins';
 
-$theme-colors: (
-  'primary': $hel-black,
-  'secondary': $hel-coat,
-  'success': $green,
-  'info': $cyan,
-  'warning': $yellow,
-  'danger': $red,
-  'light': $hel-light,
-  'dark': $hel-dark
-);
-
-$helFog: '#9fc8eb';
-$blue: '#0072c6';
-$light: '#ebedf1';
-
 $sm: 576px;
 $md: 768px;
 $lg: 992px;
 $xl: 1200px;
-
-$headingSm: 22px;
-$headingMd: 24px;
-$headingLg: 28px;

--- a/src/assets/styles/_custom-variable.scss
+++ b/src/assets/styles/_custom-variable.scss
@@ -1,8 +1,0 @@
-@import '~open-city-design/src/scss/helsinki/colors';
-@import '~open-city-design/src/scss/helsinki/fonts';
-@import '~open-city-design/src/scss/helsinki/mixins';
-
-$sm: 576px;
-$md: 768px;
-$lg: 992px;
-$xl: 1200px;

--- a/src/assets/styles/_external.scss
+++ b/src/assets/styles/_external.scss
@@ -1,2 +1,41 @@
-// Leaflet
 @import '~leaflet/dist/leaflet.css';
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/_variables';
+@import '~open-city-design/src/scss/helsinki/variables';
+
+$theme-colors: (
+  'primary': $hel-black,
+  'secondary': $hel-coat,
+  'success': $green,
+  'info': $cyan,
+  'warning': $yellow,
+  'danger': $red,
+  'light': $hel-light,
+  'dark': $hel-dark
+);
+
+$sm: 576px;
+$md: 768px;
+$lg: 992px;
+$xl: 1200px;
+
+@import '~bootstrap/scss/mixins';
+@import '~bootstrap/scss/root';
+@import '~bootstrap/scss/reboot';
+@import '~bootstrap/scss/type';
+@import '~bootstrap/scss/grid';
+@import '~bootstrap/scss/forms';
+@import '~bootstrap/scss/buttons';
+@import '~bootstrap/scss/dropdown';
+@import '~bootstrap/scss/input-group';
+@import '~bootstrap/scss/popover';
+@import '~bootstrap/scss/custom-forms';
+@import '~bootstrap/scss/nav';
+@import '~bootstrap/scss/navbar';
+@import '~bootstrap/scss/badge';
+@import '~bootstrap/scss/alert';
+@import '~bootstrap/scss/utilities';
+@import '~bootstrap/scss/print';
+
+@import '~open-city-design/src/scss/helsinki/mixins';
+@import '~open-city-design/src/scss/helsinki/custom-styles';

--- a/src/assets/styles/_normalize.scss
+++ b/src/assets/styles/_normalize.scss
@@ -1,5 +1,5 @@
 @import '~open-city-design/src/scss/helsinki/custom-styles';
-
+@import '~open-city-design/src/scss/helsinki/custom-styles';
 body,
 span,
 textarea,
@@ -22,4 +22,38 @@ h5,
 strong {
   font-family: $font-family-base;
   font-weight: $font-weight-bold;
+}
+
+.custom-select {
+  background-color: transparent;
+  border-radius: 0;
+}
+
+.btn-link.btn-link {
+  color: $hel-black;
+  text-decoration: none !important;
+  &:active,
+  &:hover {
+    color: $hel-black !important;
+    background-color: #fff !important;
+    outline: none !important;
+    box-shadow: none !important;
+  }
+}
+
+.dropdown-item.active,
+.dropdown-item:active {
+  color: #000;
+  text-decoration: none;
+  background-color: #fff;
+}
+
+h1 {
+  line-height: 1;
+  margin-bottom: 2rem;
+}
+
+h3 {
+  margin-top: 2rem;
+  margin-bottom: 1rem;
 }

--- a/src/assets/styles/_normalize.scss
+++ b/src/assets/styles/_normalize.scss
@@ -1,5 +1,3 @@
-@import '~open-city-design/src/scss/helsinki/custom-styles';
-@import '~open-city-design/src/scss/helsinki/custom-styles';
 body,
 span,
 textarea,
@@ -26,7 +24,6 @@ strong {
 
 .custom-select {
   background-color: transparent;
-  border-radius: 0;
 }
 
 .btn-link.btn-link {

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -1,10 +1,5 @@
 // External style from libraries
-
-@import 'bootstrap';
 @import 'external';
-
-// Custom variables
-@import 'custom-variable';
 
 // Custom mixins
 @import 'mixin';

--- a/src/components/berths/Berth/BerthDetails/_styles.scss
+++ b/src/components/berths/Berth/BerthDetails/_styles.scss
@@ -34,7 +34,7 @@ $berthIconSize: 42px;
   }
 
   &__icon {
-    .app-Icon {
+    .vene-icon {
       height: $berthIconSize;
       width: $berthIconSize;
       margin: 0 auto;

--- a/src/components/berths/Berth/SelectedBerth/_styles.scss
+++ b/src/components/berths/Berth/SelectedBerth/_styles.scss
@@ -25,7 +25,7 @@
     background-color: $hel-light;
     color: $hel-white;
 
-    .app-Icon {
+    .vene-icon {
       height: 36px;
       width: 36px;
     }
@@ -74,7 +74,7 @@
         background-color: $hel-fog;
       }
 
-      .app-Icon {
+      .vene-icon {
         height: 36px;
         width: 36px;
       }

--- a/src/components/berths/Berth/_styles.scss
+++ b/src/components/berths/Berth/_styles.scss
@@ -60,14 +60,14 @@ $berthImageHeight: 12em;
     }
     strong {
       line-height: 1em;
-      font-size: $headingSm;
+      font-size: $font-size-sm;
 
       @include for-tablet {
-        font-size: $headingMd;
+        font-size: $font-size-base;
       }
 
       @include for-desktop {
-        font-size: $headingLg;
+        font-size: $font-size-lg;
       }
     }
 

--- a/src/components/berths/Berth/_styles.scss
+++ b/src/components/berths/Berth/_styles.scss
@@ -86,7 +86,7 @@ $berthImageHeight: 12em;
   &__address {
     margin: 0.5em 0;
 
-    .app-Icon {
+    .vene-icon {
       height: 1em;
       width: 1em;
       display: inline-block;
@@ -98,7 +98,7 @@ $berthImageHeight: 12em;
     margin-top: 0.5em;
     font-weight: $font-weight-bold;
 
-    .app-Icon {
+    .vene-icon {
       height: 1em;
       width: 1em;
       display: inline-block;

--- a/src/components/berths/_styles.scss
+++ b/src/components/berths/_styles.scss
@@ -22,7 +22,7 @@
   }
 
   &__invalid-selection {
-    .app-Icon {
+    .vene-icon {
       width: 1em;
       height: 1em;
       fill: $hel-brick;

--- a/src/components/common/Icon/Icon.scss
+++ b/src/components/common/Icon/Icon.scss
@@ -1,0 +1,4 @@
+.vene-icon {
+  height: inherit;
+  width: auto;
+}

--- a/src/components/common/Icon/Icon.test.tsx
+++ b/src/components/common/Icon/Icon.test.tsx
@@ -1,0 +1,26 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import Icon, { IconProps } from './index';
+
+describe('common/Icon', () => {
+  const defaultProps: IconProps = {
+    name: 'helsinkiLogo'
+  };
+  const getWrapper = (props?: IconProps) => {
+    return shallow(<Icon {...defaultProps} {...props} />);
+  };
+
+  test('render Icon component', () => {
+    const icon = getWrapper();
+
+    expect(icon).toHaveLength(1);
+    expect(icon).toBeDefined();
+  });
+
+  test('Icon props contain default className', () => {
+    const icon = getWrapper({ className: 'foo', name: defaultProps.name });
+
+    expect(icon.prop('className')).toContain('vene-icon');
+    expect(icon.prop('className')).toContain('foo');
+  });
+});

--- a/src/components/common/Icon/_styles.scss
+++ b/src/components/common/Icon/_styles.scss
@@ -1,4 +1,0 @@
-.app-Icon {
-  height: inherit;
-  width: inherit;
-}

--- a/src/components/common/Icon/_styles.scss
+++ b/src/components/common/Icon/_styles.scss
@@ -1,12 +1,4 @@
 .app-Icon {
-  > div {
-    height: inherit;
-    width: inherit;
-    color: inherit;
-    svg {
-      height: inherit;
-      width: inherit;
-      color: inherit;
-    }
-  }
+  height: inherit;
+  width: inherit;
 }

--- a/src/components/common/Icon/index.tsx
+++ b/src/components/common/Icon/index.tsx
@@ -22,6 +22,8 @@ import { ReactComponent as trash } from './icons/trash-o.svg';
 import { ReactComponent as unregisteredBoat } from './icons/unregistered.svg';
 import { ReactComponent as waterTap } from './icons/water-tap.svg';
 
+import './Icon.scss';
+
 const icons = {
   helsinkiLogo,
   globe,
@@ -48,15 +50,15 @@ const icons = {
 
 export type IconNames = keyof typeof icons;
 
-interface Props {
+export interface IconProps {
   name: IconNames;
   className?: string;
 }
 
-const Icon = ({ name, className, ...rest }: Props) => {
+const Icon = ({ name, className, ...rest }: IconProps) => {
   const SvgIcon = icons[name];
 
-  return <SvgIcon className={classNames('app-Icon', className)} {...rest} />;
+  return <SvgIcon className={classNames('vene-icon', className)} {...rest} />;
 };
 
 export default Icon;

--- a/src/components/common/Icon/index.tsx
+++ b/src/components/common/Icon/index.tsx
@@ -1,27 +1,26 @@
 import classNames from 'classnames';
 import React from 'react';
-import Svg from 'react-svg';
-import angleDown from './icons/angle-down.svg';
-import angleUp from './icons/angle-up.svg';
-import arrowRight from './icons/arrow-right.svg';
-import business from './icons/business.svg';
-import check from './icons/check.svg';
-import commenting from './icons/commenting-o.svg';
-import exclamationCircle from './icons/exclamation-circle.svg';
-import fence from './icons/fence.svg';
-import globe from './icons/globe.svg';
-import helsinkiLogo from './icons/helsinki-logo.svg';
-import individual from './icons/individual.svg';
-import noBoat from './icons/noboat.svg';
-import pencil from './icons/pencil.svg';
-import plug from './icons/plug.svg';
-import pole from './icons/pole.svg';
-import registeredBoat from './icons/registered.svg';
-import streetLight from './icons/street-light.svg';
-import times from './icons/times.svg';
-import trash from './icons/trash-o.svg';
-import unregisteredBoat from './icons/unregistered.svg';
-import waterTap from './icons/water-tap.svg';
+import { ReactComponent as angleDown } from './icons/angle-down.svg';
+import { ReactComponent as angleUp } from './icons/angle-up.svg';
+import { ReactComponent as arrowRight } from './icons/arrow-right.svg';
+import { ReactComponent as business } from './icons/business.svg';
+import { ReactComponent as check } from './icons/check.svg';
+import { ReactComponent as commenting } from './icons/commenting-o.svg';
+import { ReactComponent as exclamationCircle } from './icons/exclamation-circle.svg';
+import { ReactComponent as fence } from './icons/fence.svg';
+import { ReactComponent as globe } from './icons/globe.svg';
+import { ReactComponent as helsinkiLogo } from './icons/helsinki-logo.svg';
+import { ReactComponent as individual } from './icons/individual.svg';
+import { ReactComponent as noBoat } from './icons/noboat.svg';
+import { ReactComponent as pencil } from './icons/pencil.svg';
+import { ReactComponent as plug } from './icons/plug.svg';
+import { ReactComponent as pole } from './icons/pole.svg';
+import { ReactComponent as registeredBoat } from './icons/registered.svg';
+import { ReactComponent as streetLight } from './icons/street-light.svg';
+import { ReactComponent as times } from './icons/times.svg';
+import { ReactComponent as trash } from './icons/trash-o.svg';
+import { ReactComponent as unregisteredBoat } from './icons/unregistered.svg';
+import { ReactComponent as waterTap } from './icons/water-tap.svg';
 
 const icons = {
   helsinkiLogo,
@@ -51,14 +50,13 @@ export type IconNames = keyof typeof icons;
 
 interface Props {
   name: IconNames;
-  color?: string;
-  width?: string;
-  height?: string;
   className?: string;
 }
 
-const Icon = ({ name, className, ...rest }: Props) => (
-  <Svg className={classNames('app-Icon', className)} src={icons[name]} {...rest} />
-);
+const Icon = ({ name, className, ...rest }: Props) => {
+  const SvgIcon = icons[name];
+
+  return <SvgIcon className={classNames('app-Icon', className)} {...rest} />;
+};
 
 export default Icon;

--- a/src/components/common/_styles.scss
+++ b/src/components/common/_styles.scss
@@ -1,2 +1,1 @@
-@import './Icon/styles';
 @import './Map/styles';

--- a/src/components/forms/sections/SectionSelector/_styles.scss
+++ b/src/components/forms/sections/SectionSelector/_styles.scss
@@ -10,7 +10,7 @@
     min-height: 8em;
     background-color: 'unset';
 
-    .app-Icon {
+    .vene-icon {
       fill: $hel-black;
       width: 50%;
     }

--- a/src/components/forms/sections/_styles.scss
+++ b/src/components/forms/sections/_styles.scss
@@ -19,7 +19,7 @@
     font-weight: bold;
     text-align: right;
 
-    .app-Icon {
+    .vene-icon {
       height: 30px;
       width: 30px;
       fill: $hel-black;

--- a/src/components/layout/Footer/_styles.scss
+++ b/src/components/layout/Footer/_styles.scss
@@ -25,7 +25,7 @@ $footerIconWidth: 120px;
     margin-top: 2em;
   }
 
-  .app-Icon {
+  .vene-icon {
     width: $footerIconWidth;
     fill: $hel-white;
     margin: 0 auto;

--- a/src/components/layout/Navbar/_styles.scss
+++ b/src/components/layout/Navbar/_styles.scss
@@ -19,7 +19,7 @@ $navbarTitleColor: rgba(0, 0, 0, 0.9);
   }
 
   &__language-dropdown {
-    .app-Icon {
+    .vene-icon {
       width: $languageIconSize;
       height: $languageIconSize;
       color: $hel-black;
@@ -52,7 +52,7 @@ $navbarTitleColor: rgba(0, 0, 0, 0.9);
       text-decoration: none;
     }
 
-    .app-Icon {
+    .vene-icon {
       width: $navBrandWidth;
       color: $hel-black;
     }

--- a/src/components/legends/BerthLegend/_styles.scss
+++ b/src/components/legends/BerthLegend/_styles.scss
@@ -38,7 +38,7 @@ $berthLegendIconSize: 42px;
         outline: none;
       }
 
-      .app-Icon {
+      .vene-icon {
         height: $berthLegendIconSize;
         width: $berthLegendIconSize;
       }

--- a/src/components/pages/BerthPage/SelectedBerthPage/_styles.scss
+++ b/src/components/pages/BerthPage/SelectedBerthPage/_styles.scss
@@ -28,7 +28,7 @@
     justify-content: left;
     flex-direction: row;
 
-    .app-Icon {
+    .vene-icon {
       fill: $hel-brick;
       width: 1.5em;
       height: 1.5em;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1691,11 +1691,6 @@
     "@svgr/plugin-svgo" "^4.0.3"
     loader-utils "^1.1.0"
 
-"@tanem/svg-injector@2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@tanem/svg-injector/-/svg-injector-2.1.3.tgz#660935c336870bed7fd7fcebff6792cf88b4f42b"
-  integrity sha512-/kHzXuXxzn7aVIvP/a0l4BrG82Rh95YatZx5DMg9Kh8ETH63ROw99Xx0rQT2OYNagUykApao1S8gPh7jL0CJ1g==
-
 "@tanem/svg-injector@^7.0.8":
   version "7.0.8"
   resolved "https://registry.yarnpkg.com/@tanem/svg-injector/-/svg-injector-7.0.8.tgz#2ad6c2f3f1cad5b14b555fbd3eb2011c42decd5a"
@@ -11762,15 +11757,6 @@ react-svg@*:
     "@babel/runtime" "^7.4.2"
     "@tanem/svg-injector" "^7.0.8"
     prop-types "^15.7.2"
-
-react-svg@^7.1.0:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/react-svg/-/react-svg-7.2.3.tgz#d1d9b1838a7d107c4e4bda88adb5ab88605c9f25"
-  integrity sha512-hlhNGAe8WrIp22cz97H2g+G76cOe/CkM8QaZZw2hmG6tSy5v6QaxdHMMNb97oyqA8kV0k/MJiJKDRELZI4tMew==
-  dependencies:
-    "@babel/runtime" "^7.2.0"
-    "@tanem/svg-injector" "2.1.3"
-    prop-types "^15.6.2"
 
 react-test-renderer@^16.0.0-0, react-test-renderer@^16.8.6:
   version "16.8.6"


### PR DESCRIPTION
- Remove React-svg usage cause nested DOM (hard to style), not actually necessary with help of CRA v2.
- Clean up global stylings