### PR TITLE
VEN-65 | make address, zip_code and municipality fields mandator

### DIFF
--- a/src/components/forms/fragments/PostalDetails.tsx
+++ b/src/components/forms/fragments/PostalDetails.tsx
@@ -10,6 +10,7 @@ const PostalDetailsFragment = () => (
         name={`address`}
         label={`form.postal_details.field.street_address.label`}
         placeholder={`form.postal_details.field.street_address.placeholder`}
+        required
       />
     </Col>
     <Col sm={4}>
@@ -17,6 +18,7 @@ const PostalDetailsFragment = () => (
         name={`zipCode`}
         label={`form.postal_details.field.postal_code.label`}
         placeholder={`form.postal_details.field.postal_code.placeholder`}
+        required
       />
     </Col>
     <Col sm={4}>
@@ -24,6 +26,7 @@ const PostalDetailsFragment = () => (
         name={`municipality`}
         label={`form.postal_details.field.munacipality.label`}
         placeholder={`form.postal_details.field.munacipality.placeholder`}
+        required
       />
     </Col>
   </Row>


### PR DESCRIPTION
Merging hotfix back to develop

https://github.com/City-of-Helsinki/berth-reservations-ui/pull/178