### PR TITLE
VEN-760 | Kuva test env fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+npm-debug.log
+Dockerfile*
+docker-compose*
+.dockerignore
+.git
+.gitignore
+README.md
+LICENSE
+.vscode
+build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,6 +35,7 @@ build-production:
   only:
     refs:
       - master
+      - /^release-.*$/
 
 review:
   variables:

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "redux-persist": "^5.10.0",
     "redux-promise-middleware": "^5.1.1",
     "redux-thunk": "^2.3.0",
+    "redux-devtools-extension": "^2.13.8",
     "typescript": "^3.9.5"
   },
   "scripts": {
@@ -81,7 +82,6 @@
     "husky": "^4.2.5",
     "lint-staged": "^10.2.9",
     "prettier": "^2.0.5",
-    "redux-devtools-extension": "^2.13.8",
     "tslint": "^6.1.2",
     "tslint-config-airbnb": "^5.11.2",
     "tslint-config-prettier": "^1.18.0",


### PR DESCRIPTION
- Add `.dockerignore`
- Specify redux-devtools-extension as not dev dependency
- Prod pipeline trigger fix