### PR TITLE
VEN-748 | Implement payment page layout

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -20,6 +20,7 @@ import WinterStoragePage from './pages/winterStoragePage/WinterStoragePageContai
 
 import { ApplicationType } from '../types/applicationType';
 import { LocaleOpts } from '../types/intl';
+import PaymentPage from './pages/paymentPage/PaymentPage';
 
 type Props = RouteComponentProps<{ locale: LocaleOpts }>;
 
@@ -47,6 +48,8 @@ const App = ({
       <Route exact path={`/${localeParam}/${winterParam}/selected`} component={SelectedAreaPage} />
       <Route exact path={`/${localeParam}/${winterParam}/form`} component={WinterFormPage} />
       <Route exact path={`/${localeParam}/${winterParam}/form/:tab`} component={WinterFormPage} />
+
+      <Route exact path={`/${localeParam}/payment`} component={PaymentPage} />
 
       <Route exact path={`/${localeParam}/thank-you`} component={ApplicationThankYouPage} />
       <Route exact path={`/${localeParam}/notification-sent`} component={NotificationSentPage} />

--- a/src/components/pages/paymentPage/PaymentPage.tsx
+++ b/src/components/pages/paymentPage/PaymentPage.tsx
@@ -1,0 +1,66 @@
+import React, { ChangeEvent, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Layout from '../../layout/Layout';
+import { Button } from 'reactstrap';
+import './paymentPage.scss';
+import Input from '../../common/Input';
+
+const PaymentPage = () => {
+  const { t } = useTranslation();
+  const [termsAccepted, setTermsAccepted] = useState<boolean>(false);
+
+  const handleAcceptTermsChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const target = event.target;
+    setTermsAccepted(target.checked);
+  };
+
+  const handlePay = () => {
+    alert('payment');
+  };
+
+  return (
+    <Layout>
+      <div className="vene-payment-page">
+        <div className="vene-payment-page__content-container">
+          <div className="vene-payment-page__content">
+            <h2>{t('page.payment.title')}</h2>
+            <p>{t('page.payment.terms_info')}</p>
+            <p className="vene-payment-page__contact-info">
+              {t('page.payment.questions')}&nbsp;
+              <a href="mailto:venepaikat@hel.fi" className="vene-payment-page__link">
+                venepaikat@hel.fi
+              </a>
+            </p>
+          </div>
+        </div>
+        <div className="vene-payment-page__content-container">
+          <div className="vene-payment-page__content vene-payment-page__accept-terms-content">
+            <div>
+              <a href="/" className="vene-payment-page__link">
+                {t('page.payment.terms_pdf')}
+              </a>
+            </div>
+            <div>
+              <Input
+                type="checkbox"
+                id="acceptTerms"
+                label="page.payment.accept_terms"
+                onChange={handleAcceptTermsChange}
+              />
+            </div>
+            <Button
+              className="vene-payment-page__pay-button"
+              color="secondary"
+              disabled={!termsAccepted}
+              onClick={handlePay}
+            >
+              {t('page.payment.pay')}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default PaymentPage;

--- a/src/components/pages/paymentPage/paymentPage.scss
+++ b/src/components/pages/paymentPage/paymentPage.scss
@@ -1,0 +1,59 @@
+@import 'styles/mixin';
+@import 'helsinki/colors';
+@import 'styles/variables';
+
+.vene-payment-page {
+  background-color: $hel-light;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+
+  &__content-container {
+    display: flex;
+    padding: $spacing-04 0;
+
+    &:first-child {
+      background-color: $hel-fog;
+    }
+    @include for-desktop {
+      justify-content: center;
+    }
+  }
+
+  &__content {
+    margin: 0 $spacing-01;
+
+    @include for-desktop {
+      width: $spacing-40;
+    }
+    @include for-phone {
+      width: 100%;
+    }
+  }
+
+  &__accept-terms-content {
+    > * {
+      margin-bottom: $spacing-03;
+    }
+  }
+
+  &__link {
+    color: $hel-coat;
+  }
+
+  &__pay-button {
+    padding: $spacing-01 $spacing-01;
+
+    &:disabled {
+      background: $hel-gray;
+      border-color: $hel-gray;
+    }
+    @include for-phone {
+      width: 100%;
+    }
+  }
+
+  &__contact-info {
+    margin-bottom: 0;
+  }
+}

--- a/src/components/pages/paymentPage/paymentPage.scss
+++ b/src/components/pages/paymentPage/paymentPage.scss
@@ -15,6 +15,9 @@
     &:first-child {
       background-color: $hel-fog;
     }
+    &:last-child {
+      padding-top: $spacing-02;
+    }
     @include for-desktop {
       justify-content: center;
     }

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -601,6 +601,14 @@
       },
       "title": "Kiitos!"
     },
+    "payment": {
+      "title": "Laskun maksaminen",
+      "terms_info": "Hyvä asiakkaamme, olemme päivittäneet venepaikan sopimusehtoja. Tutustu sopimusehtojen sisältöön alla. Voit jatkaa maksutapahtumaan sen jälkeen. Venepaikan saaminen edellyttää sopimusehtojen hyväksymistä.",
+      "questions": "Kysymykset ja lisätiedot: ",
+      "terms_pdf": "Venepaikan sopimusehdot (PDF)",
+      "accept_terms": "Olen lukenut venepaikan sopimusehdot ja hyväksyn ne",
+      "pay": "Jatka maksamaan"
+    },
     "winter_storage": {
       "appointed": "Merkityt ruutupaikat",
       "electricity": "Sähkö",


### PR DESCRIPTION
## Description
- Payment page layout (it should work with desktop, tablet and mobile)
- Enable pay button based on accept terms checkbox
- Translations for sv and en missing
- The actual "terms PDF" file is missing

## Testing
- Land to http://localhost:3000/fi/payment

## Related issues
[VEN-748](https://helsinkisolutionoffice.atlassian.net/browse/VEN-748)