### PR TITLE
VEN-810 | Update translations

### DIFF
--- a/src/components/common/noticeTemplate/NoticeTemplate.tsx
+++ b/src/components/common/noticeTemplate/NoticeTemplate.tsx
@@ -32,11 +32,13 @@ const NoticeTemplate = ({ titleText, message, success = false, id }: NoticePageP
           <h2>{titleText}</h2>
           {message}
         </div>
-        <LocalizedLink to="/">
-          <Button className="vene-notice-page__front-page-button" outline color="secondary">
-            {t('site.buttons.to_front_page')}
-          </Button>
-        </LocalizedLink>
+        <div className="vene-notice-page__button-wrapper">
+          <LocalizedLink to="/">
+            <Button className="vene-notice-page__front-page-button" outline color="secondary">
+              {t('site.buttons.to_front_page')}
+            </Button>
+          </LocalizedLink>
+        </div>
       </div>
     </Layout>
   );

--- a/src/components/common/noticeTemplate/noticeTemplate.scss
+++ b/src/components/common/noticeTemplate/noticeTemplate.scss
@@ -1,3 +1,4 @@
+@import 'styles/mixin';
 @import 'helsinki/colors';
 @import 'styles/variables';
 
@@ -7,7 +8,7 @@
   flex-grow: 1;
 
   &__content {
-    padding: $spacing-04 0;
+    padding: $spacing-04 $spacing-01;
   }
 
   h2 {
@@ -20,9 +21,18 @@
     margin: $spacing-01 auto;
   }
 
+  &__button-wrapper {
+    margin: 0 $spacing-01;
+  }
+
   &__front-page-button {
     margin: 0 0 $spacing-04 0;
     padding: $spacing-01 $spacing-08;
+
+    @include for-phone {
+      padding: $spacing-01 0;
+      width: 100%;
+    }
   }
 
   &--success {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -569,6 +569,40 @@
         "person": "Applicant"
       }
     },
+    "payment_error": {
+      "already_paid": {
+        "message": "The payment you attempted to make has already been marked as received. Thank you!",
+        "title": "The payment has already been made"
+      },
+      "general_error": {
+        "message": "We are sorry, but the payment could not be found. It may have been cancelled or the link may be invalid.",
+        "title": "Failure"
+      },
+      "past_due_date": {
+        "message": "We are sorry, but the payment can no longer be made because its due date has passed. Boat berth payments cannot be made past the due date.",
+        "title": "The due date has passed"
+      }
+    },
+    "payment_received": {
+      "message": {
+        "paragraph1": "Dear customer, we have received your payment. We will send you a receipt by e-mail.",
+        "paragraph2": "Enjoy your boating!"
+      },
+      "title": "Thank you!"
+    },
+    "payment_failed": {
+      "title": "Failure",
+      "paragraph1": "We are sorry, but an error occurred when processing the payment.",
+      "paragraph2": "You can try making your payment later. If necessary, please contact our customer service."
+    },
+    "payment": {
+      "title": "Paying the invoice",
+      "terms_info": "Dear customer, we have updated the agreement terms for winter storage spaces. Please read the agreement terms below. You can continue to making your payment after that. Reserving a winter storage space requires that you accept the agreement terms.",
+      "questions": "Questions and further information: ",
+      "terms_pdf": "Winter storage space agreement terms (PDF)",
+      "accept_terms": "I have read and accept the winter storage space agreement terms",
+      "pay": "Continue to making your payment"
+    },
     "winter_storage": {
       "appointed": "Appointed spaces",
       "electricity": "Electricity",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -569,6 +569,40 @@
         "person": "Sökande"
       }
     },
+    "payment_error": {
+      "already_paid": {
+        "message": "Avgiften du försökte betala är redan markerad som betald. Tack!",
+        "title": "Avgiften är redan betald."
+      },
+      "general_error": {
+        "message": "Vi beklagar men betalningen hittas inte. Den kan ha annullerats eller så kan länken vara bristfällig.",
+        "title": "Felsituation"
+      },
+      "past_due_date": {
+        "message": "Vi beklagar att avgiften inte längre kan betalas, eftersom förfallodagen överskridits. Båtplatsavgifter kan inte längre betalas efter att förfallodagen överskridits.",
+        "title": "Förfallodagen har överskridits."
+      }
+    },
+    "payment_received": {
+      "message": {
+        "paragraph1": "Bästa kund, vi har mottagit din betalning. Vi skickar dig ännu kvittot per e-post.",
+        "paragraph2": "Vi önskar dig en trevlig båtsäsong!"
+      },
+      "title": "Tack!"
+    },
+    "payment_failed": {
+      "title": "Felsituation",
+      "paragraph1": "Vi beklagar men det skedde ett fel i betalningshanteringen.",
+      "paragraph2": "Du kan senare försöka utföra betalningen på nytt, vid behov kontakta kundtjänsten."
+    },
+    "payment": {
+      "title": "Betalning av faktura",
+      "terms_info": "Bästa kund, vi har uppdaterat kontraktsvillkoren för vinterförvaringsplatserna. Bekanta dig med innehållet för kontraktsvillkoren nedan. Efter det kan du fortsätta till betalningstransaktionen. Godkännande av kontraktsvillkoren förutsätts för att få en vinterförvaringsplats.",
+      "questions": "Frågor och ytterligare uppgifter: ",
+      "terms_pdf": "Kontraktsvillkor för vinterförvaringsplats (PDF)",
+      "accept_terms": "Jag har läst kontraktsvillkoren för vinterförvaringsplatsen och godkänner dem",
+      "pay": "Fortsätt till betalningen"
+    },
     "winter_storage": {
       "appointed": "Markerade rutor",
       "electricity": "El",


### PR DESCRIPTION
## Desc
- Update en and sv translations for payments
- Improve notice template layout
  - the layout had problems with longer text content in mobile (no proper paddings and margins were in place)

## Issues
- [VEN-810](https://helsinkisolutionoffice.atlassian.net/browse/VEN-810)

## Manual testing
- Land to `http://localhost:3000/sv/payment-result?payment_status=success`
- Switch to mobile view via dev tools
- You should see that text content has left and right padding and button should take the whole width with a padding
- Text content should be in sv