### PR TITLE
VEN-758 | Translate continue button

### DIFF
--- a/src/components/pages/unmarkedWinterStoragePage/UnmarkedWinterStoragePage.tsx
+++ b/src/components/pages/unmarkedWinterStoragePage/UnmarkedWinterStoragePage.tsx
@@ -120,7 +120,7 @@ const UnmarkedWinterStoragePage = ({
           disabled={initialValues?.chosenAreas === undefined}
           onClick={moveToForm}
         >
-          Jatka
+          {t('form.wizard.button.continue')}
         </Button>
       </div>
     </Layout>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -397,6 +397,7 @@
     },
     "wizard": {
       "button": {
+        "continue": "Continue",
         "invalid": "Please complete the form to continue",
         "next": "Next",
         "previous": "Previous page",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -397,6 +397,7 @@
     },
     "wizard": {
       "button": {
+        "continue": "Jatka",
         "invalid": "Täytä lomake jatkaaksesi",
         "next": "Seuraava",
         "previous": "Edellinen sivu",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -397,6 +397,7 @@
     },
     "wizard": {
       "button": {
+        "continue": "Fortsätt",
         "invalid": "Fyll i formuläret för att fortsätta",
         "next": "Nästa",
         "previous": "Föregående sida",


### PR DESCRIPTION
## Description :sparkles:

* Add missing translations for continue button

## Issues :bug:

### Closes :no_good_woman:

* [VEN-758](https://helsinkisolutionoffice.atlassian.net/browse/VEN-758): Add missing translations

## Testing :alembic:

### Manual testing :construction_worker_man:

* Jatka/Fortsätt/Continue button on unmarked winter storage form should now be translated accordingly
