### PR TITLE
Fix custom-select padding

### DIFF
--- a/src/assets/styles/_normalize.scss
+++ b/src/assets/styles/_normalize.scss
@@ -24,7 +24,6 @@ strong {
 
 .custom-select {
   background-color: transparent;
-  padding: 0;
 
   &:invalid {
     color: $input-placeholder-color;


### PR DESCRIPTION
## Description :sparkles:
Remove the padding value for `custom-select` from `_normalize` partial

## Screenshots :camera_flash:
**Before:**
![image](https://user-images.githubusercontent.com/23040926/95422418-fa346d80-0947-11eb-8cbf-1651737b7dd4.png)
**After:**
![image](https://user-images.githubusercontent.com/23040926/95422462-0a4c4d00-0948-11eb-9e43-259692b44b66.png)


