### PR TITLE
VEN-893 | Open external links in new tab

### DIFF
--- a/src/components/layout/footer/Footer.tsx
+++ b/src/components/layout/footer/Footer.tsx
@@ -27,27 +27,43 @@ const Footer = () => {
           <Col md="4">
             <ul>
               <li>
-                <a href={t('site.footer.url.helsinki_berths')}>
+                <a
+                  href={t('site.footer.url.helsinki_berths')}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
                   <span>{t('site.footer.browse_berths')}</span>
                 </a>
               </li>
               <li>
-                <a href={t('site.footer.url.berthing')}>
+                <a href={t('site.footer.url.berthing')} rel="noopener noreferrer" target="_blank">
                   <span>{t('site.footer.boating_info')}</span>
                 </a>
               </li>
               <li>
-                <a href={t('site.footer.url.current_news')}>
+                <a
+                  href={t('site.footer.url.current_news')}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
                   <span>{t('site.footer.news')}</span>
                 </a>
               </li>
               <li>
-                <a href={t('site.footer.url.terms_of_service')}>
+                <a
+                  href={t('site.footer.url.terms_of_service')}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
                   <span>{t('site.footer.terms_of_service')}</span>
                 </a>
               </li>
               <li>
-                <a href={t('site.footer.url.accessibility_statement')}>
+                <a
+                  href={t('site.footer.url.accessibility_statement')}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
                   <span>{t('site.footer.accessibility_statement')}</span>
                 </a>
               </li>
@@ -58,10 +74,14 @@ const Footer = () => {
         <Row>
           <div className="vene-footer__bottom-link-wrapper">
             <span className="vene-footer__bottom-link">
-              <a href={t('site.footer.url.feedback')}>{t('site.footer.send_feedback')}</a>
+              <a href={t('site.footer.url.feedback')} rel="noopener noreferrer" target="_blank">
+                {t('site.footer.send_feedback')}
+              </a>
             </span>
             <span className="vene-footer__bottom-link">
-              <a href={t('site.footer.url.berthing')}>{t('site.footer.contact_us')}</a>
+              <a href={t('site.footer.url.berthing')} rel="noopener noreferrer" target="_blank">
+                {t('site.footer.contact_us')}
+              </a>
             </span>
             <span className="vene-footer__bottom-link">
               {t('site.footer.copyright', { year: new Date().getFullYear() })}

--- a/src/components/pages/berthPage/BerthPage.tsx
+++ b/src/components/pages/berthPage/BerthPage.tsx
@@ -139,9 +139,17 @@ class BerthPage extends Component<Props> {
             <>
               <p>{t('hero.berth.paragraph.first')}</p>
               <p>
-                <Trans i18nKey={'hero.berth.paragraph.second'}>
-                  A <a href={getHeroContentLink(language)}>hel.fi</a> a.
-                </Trans>
+                <Trans
+                  i18nKey={'hero.berth.paragraph.second'}
+                  components={[
+                    <a
+                      key={'berthHeroContentLink'}
+                      href={getHeroContentLink(language)}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    />,
+                  ]}
+                />
               </p>
             </>
           }

--- a/src/components/pages/berthPage/BerthPage.tsx
+++ b/src/components/pages/berthPage/BerthPage.tsx
@@ -147,7 +147,9 @@ class BerthPage extends Component<Props> {
                       href={getHeroContentLink(language)}
                       rel="noopener noreferrer"
                       target="_blank"
-                    />,
+                    >
+                      content
+                    </a>,
                   ]}
                 />
               </p>

--- a/src/components/pages/frontPage/FrontPage.tsx
+++ b/src/components/pages/frontPage/FrontPage.tsx
@@ -40,7 +40,11 @@ const FrontPage = ({ localePush }: Props) => {
                 title={t('page.front.card.berths.title')}
               >
                 <p>{t('page.front.card.berths.description')}</p>
-                <a href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/kaupungin-venepaikat/">
+                <a
+                  href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/kaupungin-venepaikat/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
                   <p>{t('page.front.card.instructions')}</p>
                 </a>
               </Card>
@@ -52,7 +56,11 @@ const FrontPage = ({ localePush }: Props) => {
                 title={t('page.front.card.winter.title')}
               >
                 <p>{t('page.front.card.winter.description')}</p>
-                <a href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneiden-talvisailytys/">
+                <a
+                  href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneiden-talvisailytys/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
                   <p>{t('page.front.card.instructions')}</p>
                 </a>
               </Card>
@@ -64,7 +72,11 @@ const FrontPage = ({ localePush }: Props) => {
                 title={t('page.front.card.unmarked_winter.title')}
               >
                 <p>{t('page.front.card.unmarked_winter.description')}</p>
-                <a href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneiden-talvisailytys/nostojarjestyksessa/">
+                <a
+                  href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneiden-talvisailytys/nostojarjestyksessa/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
                   <p>{t('page.front.card.instructions_short')}</p>
                 </a>
               </Card>

--- a/src/components/pages/paymentPage/PaymentPage.tsx
+++ b/src/components/pages/paymentPage/PaymentPage.tsx
@@ -42,7 +42,12 @@ const PaymentPage = ({ handlePay }: Props) => {
         <div className="vene-payment-page__content-container">
           <div className="vene-payment-page__content vene-payment-page__accept-terms-content">
             <div>
-              <a href={termsDocumentUrl} className="vene-payment-page__link">
+              <a
+                href={termsDocumentUrl}
+                className="vene-payment-page__link"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
                 {t('page.payment.terms_pdf')}
               </a>
             </div>

--- a/src/components/pages/unmarkedWinterStoragePage/UnmarkedWinterStoragePage.tsx
+++ b/src/components/pages/unmarkedWinterStoragePage/UnmarkedWinterStoragePage.tsx
@@ -105,7 +105,9 @@ const UnmarkedWinterStoragePage = ({
                     href={getHeroContentLink(language)}
                     rel="noopener noreferrer"
                     target="_blank"
-                  />,
+                  >
+                    content
+                  </a>,
                 ]}
               />
             </p>

--- a/src/components/pages/unmarkedWinterStoragePage/UnmarkedWinterStoragePage.tsx
+++ b/src/components/pages/unmarkedWinterStoragePage/UnmarkedWinterStoragePage.tsx
@@ -97,9 +97,17 @@ const UnmarkedWinterStoragePage = ({
           <>
             <p>{t('hero.unmarked_winter_storage.paragraph.first')}</p>
             <p>
-              <Trans i18nKey={'hero.unmarked_winter_storage.paragraph.second'}>
-                A <a href={getHeroContentLink(language)}>hel.fi</a> a. <br /> A
-              </Trans>
+              <Trans
+                i18nKey={'hero.unmarked_winter_storage.paragraph.second'}
+                components={[
+                  <a
+                    key={'unmarkedWsHeroContentLink'}
+                    href={getHeroContentLink(language)}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  />,
+                ]}
+              />
             </p>
           </>
         }

--- a/src/components/pages/winterStoragePage/WinterStorageNotice.tsx
+++ b/src/components/pages/winterStoragePage/WinterStorageNotice.tsx
@@ -35,9 +35,17 @@ const WinterStorageNotice = () => {
         <Col lg={{ size: 10, offset: 1 }} xl={{ size: 8, offset: 2 }}>
           <h3>{t('page.winter_storage.notice.title')}</h3>
           <p>
-            <Trans i18nKey={'page.winter_storage.notice.paragraph1'}>
-              A <a href={getBerthReservationsLink(language)}>venepaikat.hel.fi</a> a.
-            </Trans>
+            <Trans
+              i18nKey={'page.winter_storage.notice.paragraph1'}
+              components={[
+                <a
+                  key={'wsNoticeParagraph1Link'}
+                  href={getBerthReservationsLink(language)}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                />,
+              ]}
+            />
             {/*{t('page.winter_storage.notice.paragraph1', {
               link: (
                 <a href={t('page.winter_storage.notice.paragraph1.link_url')}>
@@ -47,9 +55,17 @@ const WinterStorageNotice = () => {
             })}*/}
           </p>
           <p>
-            <Trans i18nKey={'page.winter_storage.notice.paragraph2'}>
-              A <a href={getBoatingInfoLink(language)}>hel.fi/veneily</a> a.
-            </Trans>
+            <Trans
+              i18nKey={'page.winter_storage.notice.paragraph2'}
+              components={[
+                <a
+                  key={'wsNoticeParagraph2Link'}
+                  href={getBoatingInfoLink(language)}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                />,
+              ]}
+            />
           </p>
           <p>{t('page.winter_storage.notice.paragraph3')}</p>
         </Col>

--- a/src/components/pages/winterStoragePage/WinterStorageNotice.tsx
+++ b/src/components/pages/winterStoragePage/WinterStorageNotice.tsx
@@ -43,7 +43,9 @@ const WinterStorageNotice = () => {
                   href={getBerthReservationsLink(language)}
                   rel="noopener noreferrer"
                   target="_blank"
-                />,
+                >
+                  content
+                </a>,
               ]}
             />
             {/*{t('page.winter_storage.notice.paragraph1', {
@@ -63,7 +65,9 @@ const WinterStorageNotice = () => {
                   href={getBoatingInfoLink(language)}
                   rel="noopener noreferrer"
                   target="_blank"
-                />,
+                >
+                  content
+                </a>,
               ]}
             />
           </p>

--- a/src/components/pages/winterStoragePage/WinterStoragePage.tsx
+++ b/src/components/pages/winterStoragePage/WinterStoragePage.tsx
@@ -136,9 +136,17 @@ class WinterStoragePage extends Component<Props> {
             <>
               <p>{t('hero.winter.paragraph.first')}</p>
               <p>
-                <Trans i18nKey={'hero.winter.paragraph.second'}>
-                  A <a href={getHeroContentLink(language)}>hel.fi</a> a. <br /> A
-                </Trans>
+                <Trans
+                  i18nKey={'hero.winter.paragraph.second'}
+                  components={[
+                    <a
+                      key={'winterHeroContentLink'}
+                      href={getHeroContentLink(language)}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    />,
+                  ]}
+                />
               </p>
             </>
           }

--- a/src/components/pages/winterStoragePage/WinterStoragePage.tsx
+++ b/src/components/pages/winterStoragePage/WinterStoragePage.tsx
@@ -144,7 +144,9 @@ class WinterStoragePage extends Component<Props> {
                       href={getHeroContentLink(language)}
                       rel="noopener noreferrer"
                       target="_blank"
-                    />,
+                    >
+                      content
+                    </a>,
                   ]}
                 />
               </p>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -409,21 +409,21 @@
     "berth": {
       "paragraph": {
         "first": "This service allows for you to browse through the boat harbours in Helsinki and submit new applications to the harbours of your choice.",
-        "second": "NOTE! Please read the instructions on selecting harbours as well as further details concerning the principles of assigning berths and the processing times for applications on the <1>hel.fi</1> website before completing your application."
+        "second": "NOTE! Please read the instructions on selecting harbours as well as further details concerning the principles of assigning berths and the processing times for applications on the <0>hel.fi</0> website before completing your application."
       },
       "title": "Applying for a berth in the boat harbours of the City of Helsinki"
     },
     "winter": {
       "paragraph": {
         "first": "Here you can apply for a winter storage space for your boat in the City of Helsinki’s storage locations. Appointed spaces become available only rarely, so please also include locations with no designated spaces in your application.",
-        "second": "NOTE! Please read the instructions on selecting storage areas as well as further details concerning the principles of assigning storage spaces and the processing times for applications on the <1>hel.fi</1> website before completing your application. <3/> If you are interested in storing your boat in the water at your designated boat berth over the winter, please contact us."
+        "second": "NOTE! Please read the instructions on selecting storage areas as well as further details concerning the principles of assigning storage spaces and the processing times for applications on the <0>hel.fi</0> website before completing your application. <3/> If you are interested in storing your boat in the water at your designated boat berth over the winter, please contact us."
       },
       "title": "Winter storage place search"
     },
     "unmarked_winter_storage": {
       "paragraph": {
         "first": "Using this service, you can notify us that you have taken your boat to a unmarked winter storage area. Due to the nature of the unmarked winter storage areas, we cannot assign places in them in advance.",
-        "second": "You can find further details concerning the principles of assigning winter storage spaces, the prices and the processing of applications on the <1>hel.fi website</1>."
+        "second": "You can find further details concerning the principles of assigning winter storage spaces, the prices and the processing of applications on the <0>hel.fi website</0>."
       },
       "title": "Submit a notice that your boat has been taken to a winter storage area"
     }
@@ -679,8 +679,8 @@
       "maximum_length": "Max. length",
       "maximum_width": "Max. width",
       "notice": {
-        "paragraph1": "Applying for winter storage spaces in the 2020–2021 season is now current. Customers who have had a square space in the last season will be sent an invoice for the space. If you are a new applicant, you can apply for a square space by filling out the online application at <1>venepaikat.hel.fi/en</1>. Available squares will be assigned on a first-come, first-served basis in the autumn. We will send offers for these spaces by e-mail.",
-        "paragraph2": "Customers who have had a winter storage space in a unmarked winter storage area will not be sent an invoice. Instead, they can pay their fee onto the berth reservation account after the boat has been brought to the unmarked winter storage area. We will provide information about paying for unmarked winter storage area spaces later online at <1>hel.fi/boating</1> and on the information boards of unmarked winter storage areas. Customers who have paid for a winter storage space will be sent a winter storage sticker to be attached to their boats on a visible spot.",
+        "paragraph1": "Applying for winter storage spaces in the 2020–2021 season is now current. Customers who have had a square space in the last season will be sent an invoice for the space. If you are a new applicant, you can apply for a square space by filling out the online application at <0>venepaikat.hel.fi/en</0>. Available squares will be assigned on a first-come, first-served basis in the autumn. We will send offers for these spaces by e-mail.",
+        "paragraph2": "Customers who have had a winter storage space in a unmarked winter storage area will not be sent an invoice. Instead, they can pay their fee onto the berth reservation account after the boat has been brought to the unmarked winter storage area. We will provide information about paying for unmarked winter storage area spaces later online at <0>hel.fi/boating</0> and on the information boards of unmarked winter storage areas. Customers who have paid for a winter storage space will be sent a winter storage sticker to be attached to their boats on a visible spot.",
         "paragraph3": "Boaters can bring their boats to the unmarked winter storage area of their choosing starting from 15 September 2020. Please note that boats must not be brought to unmarked winter storage areas before the storage season starts on 15 September.",
         "title": "Applying for winter storage spaces 2020–2021"
       },

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -409,21 +409,21 @@
     "berth": {
       "paragraph": {
         "first": "Tässä palvelussa voit selata Helsingin kaupungin venesatamia ja tehdä uuden venepaikkahakemuksen valitsemiisi satamiin.",
-        "second": "HUOM! Ennen kuin täytät hakemuksen, lue ohjeet satamien valintaan sekä tietoa venepaikkojen jakoperusteista ja hakemuskäsittelyn aikataulusta <1>hel.fi</1> -sivustolta."
+        "second": "HUOM! Ennen kuin täytät hakemuksen, lue ohjeet satamien valintaan sekä tietoa venepaikkojen jakoperusteista ja hakemuskäsittelyn aikataulusta <0>hel.fi</0> -sivustolta."
       },
       "title": "Venepaikan hakeminen Helsingin venesatamista"
     },
     "winter": {
       "paragraph": {
         "first": "Tästä voit hakea veneen talvisäilytyspaikkaa Helsingin kaupungin säilytysalueilta. Ruutupaikkoja vapautuu harvoin joten valitsethan hakemukseesi myös alueita joissa ei ole merkittyjä paikkoja.",
-        "second": "HUOM! Ennen kuin täytät hakemuksen, lue ohjeet alueiden valintaan sekä tietoa säilytyspaikkojen jakoperusteista ja hakemuskäsittelyn aikataulusta <1>hel.fi</1> -sivustolta. <3/> Jos olet kiinnostunut talvisäilyttämään veneesi vedessä omalla venepaikallasi ota meihin yhteyttä."
+        "second": "HUOM! Ennen kuin täytät hakemuksen, lue ohjeet alueiden valintaan sekä tietoa säilytyspaikkojen jakoperusteista ja hakemuskäsittelyn aikataulusta <0>hel.fi</0> -sivustolta. <3/> Jos olet kiinnostunut talvisäilyttämään veneesi vedessä omalla venepaikallasi ota meihin yhteyttä."
       },
       "title": "Talvisäilytyspaikkojen haku"
     },
     "unmarked_winter_storage": {
       "paragraph": {
         "first": "Tässä palvelussa voit ilmoittaa meille että olet vienyt veneesi nostojärjestysalueelle. Nostojärjestysalueiden luonteesta johtuen emme voi jakaa paikkoja niille etukäteen.",
-        "second": "Tarkempia tietoja talvisäilytyspaikkojen jakoperusteista, hinnoista ja hakemusten käsittelystä löydät <1>hel.fi-sivustolta</1>."
+        "second": "Tarkempia tietoja talvisäilytyspaikkojen jakoperusteista, hinnoista ja hakemusten käsittelystä löydät <0>hel.fi-sivustolta</0>."
       },
       "title": "Ilmoita että veneesi on viety talvisäilytysalueelle"
     }
@@ -679,8 +679,8 @@
       "maximum_length": "Max. pituus",
       "maximum_width": "Max. leveys",
       "notice": {
-        "paragraph1": "Talvisäilytyspaikkojen haku kaudelle 2020–2021 on nyt ajankohtainen. Niille asiakkaille, joilla on ollut ruutupaikka viime kaudella, lähetetään lasku paikasta. Mikäli olet uusi hakija, hae ruutupaikkaa tekemällä sähköinen hakemus verkossa osoitteessa <1>venepaikat.hel.fi</1>. Vapautuneet ruudut jaetaan hakujärjestyksessä syksyllä. Lähetämme paikasta tarjouksen sähköpostilla.",
-        "paragraph2": "Niille asiakkaille, joilla on ollut talvisäilytyspaikka nostojärjestysalueella, emme lähetä laskua vaan maksaminen tapahtuu venepaikkavarausten tilille sen jälkeen, kun vene on viety nostojärjestysalueelle. Tiedotamme nostojärjestysaluepaikan maksamisesta myöhemmin verkossa osoitteessa <1>hel.fi/veneily</1> sekä nostojärjestysalueiden infotauluissa. Talvisäilytyspaikan maksaneille asiakkaille lähetetään talvisäilytys-tarra, joka kiinnitetään näkyvälle paikalle veneeseen.",
+        "paragraph1": "Talvisäilytyspaikkojen haku kaudelle 2020–2021 on nyt ajankohtainen. Niille asiakkaille, joilla on ollut ruutupaikka viime kaudella, lähetetään lasku paikasta. Mikäli olet uusi hakija, hae ruutupaikkaa tekemällä sähköinen hakemus verkossa osoitteessa <0>venepaikat.hel.fi</0>. Vapautuneet ruudut jaetaan hakujärjestyksessä syksyllä. Lähetämme paikasta tarjouksen sähköpostilla.",
+        "paragraph2": "Niille asiakkaille, joilla on ollut talvisäilytyspaikka nostojärjestysalueella, emme lähetä laskua vaan maksaminen tapahtuu venepaikkavarausten tilille sen jälkeen, kun vene on viety nostojärjestysalueelle. Tiedotamme nostojärjestysaluepaikan maksamisesta myöhemmin verkossa osoitteessa <0>hel.fi/veneily</0> sekä nostojärjestysalueiden infotauluissa. Talvisäilytyspaikan maksaneille asiakkaille lähetetään talvisäilytys-tarra, joka kiinnitetään näkyvälle paikalle veneeseen.",
         "paragraph3": "Veneilijät voivat viedä veneensä haluamalleen nostojärjestysalueelle 15.9.2020 alkaen. Huomioithan, että nostojärjestysalueille ei tule viedä veneitä ennen 15.9. alkavaa säilytyskautta.",
         "title": "Talvisäilytyspaikkojen 2020–2021 hakeminen"
       },

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -409,21 +409,21 @@
     "berth": {
       "paragraph": {
         "first": "I denna tjänst kan du bläddra bland Helsingfors stads båthamnar och göra en ny ansökan om båtplats i önskade hamnar.",
-        "second": "OBS! Läs igenom anvisningarna för val av hamnar samt informationen om såväl reglerna för utdelning av båtplatser som tidsschemat för handläggningen av ansökningar på <1>hel.fi</1> innan du fyller i ansökan."
+        "second": "OBS! Läs igenom anvisningarna för val av hamnar samt informationen om såväl reglerna för utdelning av båtplatser som tidsschemat för handläggningen av ansökningar på <0>hel.fi</0> innan du fyller i ansökan."
       },
       "title": "Ansökan om båtplats i Helsingfors båthamnar"
     },
     "winter": {
       "paragraph": {
         "first": "Här kan du ansöka om vinteruppläggningsplats i något av Helsingfors stads förvaringsområden. Rutor blir sällan lediga så välj också områden utan markerade platser för din ansökan.",
-        "second": "OBS! Läs igenom anvisningarna för val av förvaringsområden samt information om såväl reglerna för utdelning av uppläggningsplatser som tidsschemat för handläggningen av ansökningar på <1>hel.fi</1> innan du fyller i ansökan. <3/> Kontakta oss om du är intresserad av att lägga upp din båt på din egen båtplats för vintern."
+        "second": "OBS! Läs igenom anvisningarna för val av förvaringsområden samt information om såväl reglerna för utdelning av uppläggningsplatser som tidsschemat för handläggningen av ansökningar på <0>hel.fi</0> innan du fyller i ansökan. <3/> Kontakta oss om du är intresserad av att lägga upp din båt på din egen båtplats för vintern."
       },
       "title": "Ansökan om vinteruppläggningsplatser"
     },
     "unmarked_winter_storage": {
       "paragraph": {
         "first": "I den här tjänsten kan du meddela oss att du fört din båt till ett område för vinteruppläggning som fylls i upptagningsordning. På grund av dessa områdens \nkaraktär kan vi inte dela ut platser på dem i förväg.",
-        "second": "Närmare information om grunderna för utdelning av vinteruppläggningsplatser, priserna och handläggningen av ansökningar finns på webbplatsen <1>hel.fi</1>."
+        "second": "Närmare information om grunderna för utdelning av vinteruppläggningsplatser, priserna och handläggningen av ansökningar finns på webbplatsen <0>hel.fi</0>."
       },
       "title": "Anmäl att din båt har förts till ett upplagsområde"
     }
@@ -679,8 +679,8 @@
       "maximum_length": "Max. längd",
       "maximum_width": "Max. bredd",
       "notice": {
-        "paragraph1": "Ansökan om vinteruppläggningsplatser för säsongen 2020–2021 är nu aktuell. Vi skickar en faktura till de kunder som har haft rutplats förra säsongen. Om du är ny sökande, ansök om rutplats genom att göra en elektronisk ansökan på webben på <1>venepaikat.hel.fi/sv</1>. Lediga rutplatser delas ut på hösten i ansökningsordning. Vi skickar ut erbjudande om plats via e-post.",
-        "paragraph2": "Vi skickar inte någon faktura till de kunder som har haft vinteruppläggningsplats i upptagningsordningsområdet, utan betalning sker till båtplatsreserveringens konto efter att båten har tagits till upptagningsordningsområdet. Vi informerar senare på webben om betalning för plats i upptagningsordningsområdet på adressen <1>hel.fi/båtliv</1>, samt på upptagningsordningsområdets infotavlor. Till de kunder som har betalat för en vinteruppläggningsplats skickas en vinteruppläggningsdekal till hemadressen, Vi ber er klistra dekalen på en synlig plats på båten.",
+        "paragraph1": "Ansökan om vinteruppläggningsplatser för säsongen 2020–2021 är nu aktuell. Vi skickar en faktura till de kunder som har haft rutplats förra säsongen. Om du är ny sökande, ansök om rutplats genom att göra en elektronisk ansökan på webben på <0>venepaikat.hel.fi/sv</0>. Lediga rutplatser delas ut på hösten i ansökningsordning. Vi skickar ut erbjudande om plats via e-post.",
+        "paragraph2": "Vi skickar inte någon faktura till de kunder som har haft vinteruppläggningsplats i upptagningsordningsområdet, utan betalning sker till båtplatsreserveringens konto efter att båten har tagits till upptagningsordningsområdet. Vi informerar senare på webben om betalning för plats i upptagningsordningsområdet på adressen <0>hel.fi/båtliv</0>, samt på upptagningsordningsområdets infotavlor. Till de kunder som har betalat för en vinteruppläggningsplats skickas en vinteruppläggningsdekal till hemadressen, Vi ber er klistra dekalen på en synlig plats på båten.",
         "paragraph3": "Båtägarna kan ta sin båt till önskat upptagningsordningsområde från och med den 15 september 2020. Observera att man inte får ta båtar till upptagningsordningsområdena innan uppläggningstiden börjar den 15 september 2020.",
         "title": "Ansökan om vinteruppläggningsplatser 2020–2021"
       },


### PR DESCRIPTION
## Description :sparkles:

* Open external links in new tab

## Issues :bug:

### Closes :no_good_woman:

* [VEN-893](https://helsinkisolutionoffice.atlassian.net/browse/VEN-893): FE: Customer contract (shown before the customer proceeds to Bambora payment page) should open in a new tab/window

## Testing :alembic:

### Manual testing :construction_worker_man:

* Check that contract terms open in new tab
* Check that footer links open in new tab
* Check that all external links on the first form pages open in new tab
