### PR TITLE
VEN-892 | Separate prioritized municipalities in PostalDetails

### DIFF
--- a/src/components/forms/fragments/PostalDetails.tsx
+++ b/src/components/forms/fragments/PostalDetails.tsx
@@ -2,11 +2,24 @@ import React from 'react';
 import { Col, Row } from 'reactstrap';
 
 import { Select, Text } from '../Fields';
-import { MUNICIPALITIES } from '../../../constants/Municipalities';
+import { MUNICIPALITIES, PRIORITIZED_MUNICIPALITIES } from '../../../constants/Municipalities';
 import { useTranslation } from 'react-i18next';
 
 const PostalDetailsFragment = () => {
   const { t, i18n } = useTranslation();
+
+  const renderMunicipalityOption = (municipality: {
+    id: string;
+    translations: Record<string, string>;
+  }) => {
+    const translated = municipality.translations[i18n.language] ?? municipality.translations.fi;
+    return (
+      <option key={municipality.id} value={municipality.translations.fi}>
+        {translated}
+      </option>
+    );
+  };
+
   return (
     <Row>
       <Col sm={4}>
@@ -31,20 +44,14 @@ const PostalDetailsFragment = () => {
           label={`form.postal_details.field.municipality.label`}
           required
         >
-          <option value="" disabled selected hidden>
+          <option value="" disabled hidden>
             {t('form.postal_details.field.municipality.placeholder')}
           </option>
-          {MUNICIPALITIES.map(
-            (municipality: { id: string; translations: Record<string, string> }) => {
-              const translated =
-                municipality.translations[i18n.language] ?? municipality.translations.fi;
-              return (
-                <option key={municipality.id} value={municipality.translations.fi}>
-                  {translated}
-                </option>
-              );
-            }
-          )}
+          {PRIORITIZED_MUNICIPALITIES.map(renderMunicipalityOption)}
+          <option value="" disabled>
+            -
+          </option>
+          {MUNICIPALITIES.map(renderMunicipalityOption)}
         </Select>
       </Col>
     </Row>

--- a/src/constants/Municipalities.ts
+++ b/src/constants/Municipalities.ts
@@ -1,8 +1,11 @@
-export const MUNICIPALITIES = [
+export const PRIORITIZED_MUNICIPALITIES = [
   { id: 'helsinki', translations: { sv: 'Helsingfors', fi: 'Helsinki' } },
   { id: 'espoo', translations: { sv: 'Esbo', fi: 'Espoo' } },
   { id: 'vantaa', translations: { sv: 'Vanda', fi: 'Vantaa' } },
   { id: 'kauniainen', translations: { sv: 'Grankulla', fi: 'Kauniainen' } },
+];
+
+export const MUNICIPALITIES = [
   { id: 'akaa', translations: { sv: 'Akaa', fi: 'Akaa' } },
   { id: 'alajärvi', translations: { sv: 'Alajärvi', fi: 'Alajärvi' } },
   { id: 'alavieska', translations: { sv: 'Alavieska', fi: 'Alavieska' } },
@@ -14,6 +17,7 @@ export const MUNICIPALITIES = [
   { id: 'eckerö', translations: { sv: 'Eckerö', fi: 'Eckerö' } },
   { id: 'enonkoski', translations: { sv: 'Enonkoski', fi: 'Enonkoski' } },
   { id: 'enontekiö', translations: { sv: 'Enontekis', fi: 'Enontekiö' } },
+  { id: 'espoo', translations: { sv: 'Esbo', fi: 'Espoo' } },
   { id: 'eura', translations: { sv: 'Eura', fi: 'Eura' } },
   { id: 'eurajoki', translations: { sv: 'Euraåminne', fi: 'Eurajoki' } },
   { id: 'evijärvi', translations: { sv: 'Evijärvi', fi: 'Evijärvi' } },
@@ -35,6 +39,7 @@ export const MUNICIPALITIES = [
   { id: 'hausjärvi', translations: { sv: 'Hausjärvi', fi: 'Hausjärvi' } },
   { id: 'heinola', translations: { sv: 'Heinola', fi: 'Heinola' } },
   { id: 'heinävesi', translations: { sv: 'Heinävesi', fi: 'Heinävesi' } },
+  { id: 'helsinki', translations: { sv: 'Helsingfors', fi: 'Helsinki' } },
   { id: 'hirvensalmi', translations: { sv: 'Hirvensalmi', fi: 'Hirvensalmi' } },
   { id: 'hollola', translations: { sv: 'Hollola', fi: 'Hollola' } },
   { id: 'honkajoki', translations: { sv: 'Honkajoki', fi: 'Honkajoki' } },
@@ -85,6 +90,7 @@ export const MUNICIPALITIES = [
   { id: 'kaskinen', translations: { sv: 'Kaskö', fi: 'Kaskinen' } },
   { id: 'kauhajoki', translations: { sv: 'Kauhajoki', fi: 'Kauhajoki' } },
   { id: 'kauhava', translations: { sv: 'Kauhava', fi: 'Kauhava' } },
+  { id: 'kauniainen', translations: { sv: 'Grankulla', fi: 'Kauniainen' } },
   { id: 'kaustinen', translations: { sv: 'Kaustby', fi: 'Kaustinen' } },
   { id: 'keitele', translations: { sv: 'Keitele', fi: 'Keitele' } },
   { id: 'kemi', translations: { sv: 'Kemi', fi: 'Kemi' } },
@@ -293,6 +299,7 @@ export const MUNICIPALITIES = [
   { id: 'vaasa', translations: { sv: 'Vasa', fi: 'Vaasa' } },
   { id: 'valkeakoski', translations: { sv: 'Valkeakoski', fi: 'Valkeakoski' } },
   { id: 'valtimo', translations: { sv: 'Valtimo', fi: 'Valtimo' } },
+  { id: 'vantaa', translations: { sv: 'Vanda', fi: 'Vantaa' } },
   { id: 'varkaus', translations: { sv: 'Varkaus', fi: 'Varkaus' } },
   { id: 'vehmaa', translations: { sv: 'Vehmaa', fi: 'Vehmaa' } },
   { id: 'vesanto', translations: { sv: 'Vesanto', fi: 'Vesanto' } },


### PR DESCRIPTION
## Description :sparkles:

Prioritized municipalities should appear twice in the select: at the top, and in the full list, with a divider in between.

### Closes :no_good_woman:

[VEN-892](https://helsinkisolutionoffice.atlassian.net/browse/VEN-892)
