### PR TITLE
Change review and staging urls to point to new backend

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ build-review:
   extends: .build
   variables:
     DOCKER_IMAGE_NAME: '$CI_PROJECT_NAME-review'
-    DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://venepaikka-api.test.hel.ninja/graphql/'
+    DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://venepaikka-api.test.kuva.hel.ninja/graphql/'
     DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'development'
     DOCKER_BUILD_ARG_REACT_APP_SENTRY_ENVIRONMENT: 'review'
   only:
@@ -25,7 +25,7 @@ build-staging:
   extends: .build
   variables:
     DOCKER_IMAGE_NAME: '$CI_PROJECT_NAME-staging'
-    DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://venepaikka-api.test.hel.ninja/graphql/'
+    DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://venepaikka-api.test.kuva.hel.ninja/graphql/'
     DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'development'
     DOCKER_BUILD_ARG_REACT_APP_SENTRY_ENVIRONMENT: 'staging'
   only:


### PR DESCRIPTION
## Description :sparkles:
Change the urls in review and staging to point to the new KUVA-hosted backend endpoint for the customer ui as well.

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:
VEN-863

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

