### PR TITLE
VEN-808 | Browser tests

### DIFF
--- a/.testcaferc.json
+++ b/.testcaferc.json
@@ -1,0 +1,7 @@
+{
+  "clientScripts": [
+    {
+      "module": "@testing-library/dom/dist/@testing-library/dom.umd.js"
+    }
+  ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,19 @@ before_install:
   - export PATH="$HOME/.yarn/bin:$PATH"
 install:
   - yarn
-script:
-  - yarn lint
-  - yarn build
-  - yarn test:ci
+jobs:
+  include:
+    - stage: 'Test'
+      name: 'Run code linting and test'
+      script: yarn lint && yarn test:ci
+    - stage: 'Build'
+      name: 'Run (test) build'
+      if: branch IN (master)
+      script: yarn build
+    - stage: 'Browser test'
+      name: 'Run browser tests'
+      if: type = cron
+      script: yarn browser-test:ci
 
 after_success:
   - codecov < coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ To run tests:
 $ yarn test
 ```
 
+## Browser tests
+
+Browser tests are written in TypeScript with [TestCafe](https://devexpress.github.io/testcafe/) framework and they are run against [test environment](https://venepaikka.test.kuva.hel.ninja) in CI as Travis Cron Job (daily) with Chrome (headless mode).
+
+### How to run locally
+
+Running against test environment
+
+- `yarn browser-test`
+
+Running against local environment
+
+- `yarn browser-test:local`
+
 ## Useful docker command
 
 - To rebuild the docker images:

--- a/browser-tests/berth.ts
+++ b/browser-tests/berth.ts
@@ -2,26 +2,27 @@ import { berth } from './selectors/berth';
 import { navbar } from './selectors/navbar';
 import { isBerthsPage } from './utils/page';
 import { envUrl } from './utils/settings';
+import { applicantInformation, overview, yourSelection } from './utils/sharedTests';
 
 const testData = {
+  address: 'Testiosoite 1',
+  boatDraught: '0.21',
+  boatLength: '4.4',
+  boatModel: 'Terhi 440',
+  boatName: 'Testivene',
+  boatRegistrationNumber: 'P12345',
   boatType: 'Soutuvene',
   boatTypeIndex: '2',
-  boatWidth: '1.75',
-  boatLength: '4.4',
-  harbor1: 'Lähteelä retkisatama',
-  harbor2: 'Strömsinlahden venesatama',
-  boatRegistrationNumber: 'P12345',
-  boatDraught: '0.21',
   boatWeight: '150',
-  boatName: 'Testivene',
-  boatModel: 'Terhi 440',
+  boatWidth: '1.75',
+  choice1: 'Lähteelä retkisatama',
+  choice2: 'Strömsinlahden venesatama',
+  emailAddress: 'test@example.com',
   firstName: 'Matti',
   lastName: 'Meikäläinen',
-  address: 'Testiosoite 1',
-  postalCode: '02100',
   municipality: 'Espoo',
   phoneNumber: '+358 50 123 4567',
-  emailAddress: 'test@example.com',
+  postalCode: '02100',
 };
 
 fixture('Berth').page(envUrl());
@@ -31,10 +32,21 @@ test('New berth application, registered boat, private customer', async (t) => {
   await isBerthsPage();
 
   await selectHarbors(t);
-  await yourSelection(t);
+  await yourSelection(t, testData);
   await boatInformation(t);
-  await applicantInformation(t);
-  await overview(t);
+  await applicantInformation(t, testData);
+
+  const expectedBoatInfo = [
+    `Nimi: ${testData.boatName}`,
+    `Rekisterinumero: ${testData.boatRegistrationNumber}`,
+    `Tyyppi: ${testData.boatType}`,
+    `Malli: ${testData.boatModel}`,
+    `Leveys: ${testData.boatWidth}m`,
+    `Pituus: ${testData.boatLength}m`,
+    `Syväys: ${testData.boatDraught}m`,
+    `Paino: ${testData.boatWeight}`,
+  ].join('\n');
+  await overview(t, testData, expectedBoatInfo);
 });
 
 const selectHarbors = async (t: TestController) => {
@@ -61,24 +73,8 @@ const selectHarbors = async (t: TestController) => {
 
   await t
     .click(harborListTab)
-    .click(getSelectButtonForHarbor(testData.harbor1))
-    .click(getSelectButtonForHarbor(testData.harbor2));
-
-  await t.click(nextButton);
-};
-
-const yourSelection = async (t: TestController) => {
-  const { heading, getHarborHeading, getUpButtonForHeading, nextButton } = berth.yourSelection;
-
-  await t.expect(heading.exists).ok();
-
-  await t.click(getUpButtonForHeading(getHarborHeading(`2. ${testData.harbor2}`))).wait(500);
-
-  await t
-    .expect(getHarborHeading(`1. ${testData.harbor2}`).exists)
-    .ok()
-    .expect(getHarborHeading(`2. ${testData.harbor1}`).exists)
-    .ok();
+    .click(getSelectButtonForHarbor(testData.choice1))
+    .click(getSelectButtonForHarbor(testData.choice2));
 
   await t.click(nextButton);
 };
@@ -104,76 +100,4 @@ const boatInformation = async (t: TestController) => {
     .typeText(boatModel, testData.boatModel);
 
   await t.click(nextButton);
-};
-
-const applicantInformation = async (t: TestController) => {
-  const {
-    heading,
-    firstName,
-    lastName,
-    address,
-    postalCode,
-    municipalitySelect,
-    phoneNumber,
-    emailAddress,
-    nextButton,
-  } = berth.applicantInformation;
-
-  await t.expect(heading.exists).ok();
-
-  await t
-    .typeText(firstName, testData.firstName)
-    .typeText(lastName, testData.lastName)
-    .typeText(address, testData.address)
-    .typeText(postalCode, testData.postalCode)
-    .click(municipalitySelect)
-    .click(municipalitySelect.find('option').withText(testData.municipality))
-    .typeText(phoneNumber, testData.phoneNumber)
-    .typeText(emailAddress, testData.emailAddress);
-
-  await t.click(nextButton);
-};
-
-const overview = async (t: TestController) => {
-  const { heading, textInOverview, getLabelValuePairs } = berth.overview;
-
-  await t.expect(heading.exists).ok();
-
-  // Boat information
-  const labelValuePairs = await getLabelValuePairs();
-  const expectedContent = [
-    `Nimi: ${testData.boatName}`,
-    `Rekisterinumero: ${testData.boatRegistrationNumber}`,
-    `Tyyppi: ${testData.boatType}`,
-    `Malli: ${testData.boatModel}`,
-    `Leveys: ${testData.boatWidth}m`,
-    `Pituus: ${testData.boatLength}m`,
-    `Syväys: ${testData.boatDraught}m`,
-    `Paino: ${testData.boatWeight}`,
-  ].join('\n');
-  await t.expect(labelValuePairs).eql(expectedContent);
-
-  // Chosen harbors
-  await t
-    .expect(textInOverview(`1. ${testData.harbor2}`).exists)
-    .ok()
-    .expect(textInOverview(`2. ${testData.harbor1}`).exists)
-    .ok();
-
-  // Applicant
-  await t
-    .expect(textInOverview(testData.firstName).exists)
-    .ok()
-    .expect(textInOverview(testData.lastName).exists)
-    .ok()
-    .expect(textInOverview(testData.emailAddress).exists)
-    .ok()
-    .expect(textInOverview(testData.phoneNumber).exists)
-    .ok()
-    .expect(textInOverview(testData.address).exists)
-    .ok()
-    .expect(textInOverview(testData.postalCode).exists)
-    .ok()
-    .expect(textInOverview(testData.municipality).exists)
-    .ok();
 };

--- a/browser-tests/berth.ts
+++ b/browser-tests/berth.ts
@@ -1,5 +1,6 @@
-import { berth } from './selectors/berth';
-import { navbar } from './selectors/navbar';
+import berth from './selectors/berth';
+import navbar from './selectors/navbar';
+import shared from './selectors/shared';
 import { isBerthsPage } from './utils/page';
 import { envUrl } from './utils/settings';
 import { applicantInformation, overview, yourSelection } from './utils/sharedTests';
@@ -88,7 +89,7 @@ const boatInformation = async (t: TestController) => {
     boatName,
     boatModel,
     nextButton,
-  } = berth.boatInformation;
+  } = shared.boatInformation;
 
   await t.expect(heading.exists).ok();
 

--- a/browser-tests/berth.ts
+++ b/browser-tests/berth.ts
@@ -1,6 +1,7 @@
 import { selectHarborsSelectors } from './selectors/berth';
 import { navbarSelectors } from './selectors/navbar';
 import { boatInformationSelectors } from './selectors/shared';
+import { ApplicantInformation, BerthBoatInformation, Choices } from './types/types';
 import { isBerthsPage } from './utils/page';
 import { envUrl } from './utils/settings';
 import {
@@ -9,7 +10,7 @@ import {
   swapSelections,
 } from './sharedTests/sharedTests';
 
-const testData = {
+const testData: Choices & BerthBoatInformation & ApplicantInformation = {
   address: 'Testiosoite 1',
   boatDraught: '0.21',
   boatLength: '4.4',

--- a/browser-tests/berth.ts
+++ b/browser-tests/berth.ts
@@ -3,7 +3,11 @@ import { navbarSelectors } from './selectors/navbar';
 import { boatInformationSelectors } from './selectors/shared';
 import { isBerthsPage } from './utils/page';
 import { envUrl } from './utils/settings';
-import { applicantInformation, overview, yourSelection } from './utils/sharedTests';
+import {
+  fillApplicantInformation,
+  assertOverview,
+  swapSelections,
+} from './sharedTests/sharedTests';
 
 const testData = {
   address: 'Testiosoite 1',
@@ -33,9 +37,9 @@ test('New berth application, registered boat, private customer', async (t) => {
   await isBerthsPage();
 
   await selectHarbors(t);
-  await yourSelection(t, testData);
-  await boatInformation(t);
-  await applicantInformation(t, testData);
+  await swapSelections(t, testData);
+  await fillBoatInformation(t);
+  await fillApplicantInformation(t, testData);
 
   const expectedBoatInfo = [
     `Nimi: ${testData.boatName}`,
@@ -47,7 +51,7 @@ test('New berth application, registered boat, private customer', async (t) => {
     `Syväys: ${testData.boatDraught}m`,
     `Paino: ${testData.boatWeight}`,
   ].join('\n');
-  await overview(t, testData, expectedBoatInfo);
+  await assertOverview(t, testData, expectedBoatInfo);
 });
 
 const selectHarbors = async (t: TestController) => {
@@ -80,7 +84,7 @@ const selectHarbors = async (t: TestController) => {
   await t.click(nextButton);
 };
 
-const boatInformation = async (t: TestController) => {
+const fillBoatInformation = async (t: TestController) => {
   const {
     heading,
     boatRegistrationNumber,

--- a/browser-tests/berth.ts
+++ b/browser-tests/berth.ts
@@ -1,0 +1,179 @@
+import { berth } from './selectors/berth';
+import { navbar } from './selectors/navbar';
+import { isBerthsPage } from './utils/page';
+import { envUrl } from './utils/settings';
+
+const testData = {
+  boatType: 'Soutuvene',
+  boatTypeIndex: '2',
+  boatWidth: '1.75',
+  boatLength: '4.4',
+  harbor1: 'Lähteelä retkisatama',
+  harbor2: 'Strömsinlahden venesatama',
+  boatRegistrationNumber: 'P12345',
+  boatDraught: '0.21',
+  boatWeight: '150',
+  boatName: 'Testivene',
+  boatModel: 'Terhi 440',
+  firstName: 'Matti',
+  lastName: 'Meikäläinen',
+  address: 'Testiosoite 1',
+  postalCode: '02100',
+  municipality: 'Espoo',
+  phoneNumber: '+358 50 123 4567',
+  emailAddress: 'test@example.com',
+};
+
+fixture('Berth').page(envUrl());
+
+test('New berth application, registered boat, private customer', async (t) => {
+  await t.click(navbar.berths);
+  await isBerthsPage();
+
+  await selectHarbors(t);
+  await yourSelection(t);
+  await boatInformation(t);
+  await applicantInformation(t);
+  await overview(t);
+});
+
+const selectHarbors = async (t: TestController) => {
+  const {
+    boatTypeSelect,
+    boatWidth,
+    boatLength,
+    wasteCollection,
+    harborListTab,
+    nextButton,
+    getSelectButtonForHarbor,
+  } = berth.selectHarbors;
+
+  await t
+    .click(boatTypeSelect)
+    .click(boatTypeSelect.find('option').withText(testData.boatType))
+    .expect(boatTypeSelect.value)
+    .eql(testData.boatTypeIndex);
+
+  await t
+    .typeText(boatWidth, testData.boatWidth)
+    .typeText(boatLength, testData.boatLength)
+    .click(wasteCollection);
+
+  await t
+    .click(harborListTab)
+    .click(getSelectButtonForHarbor(testData.harbor1))
+    .click(getSelectButtonForHarbor(testData.harbor2));
+
+  await t.click(nextButton);
+};
+
+const yourSelection = async (t: TestController) => {
+  const { heading, getHarborHeading, getUpButtonForHeading, nextButton } = berth.yourSelection;
+
+  await t.expect(heading.exists).ok();
+
+  await t.click(getUpButtonForHeading(getHarborHeading(`2. ${testData.harbor2}`))).wait(500);
+
+  await t
+    .expect(getHarborHeading(`1. ${testData.harbor2}`).exists)
+    .ok()
+    .expect(getHarborHeading(`2. ${testData.harbor1}`).exists)
+    .ok();
+
+  await t.click(nextButton);
+};
+
+const boatInformation = async (t: TestController) => {
+  const {
+    heading,
+    boatRegistrationNumber,
+    boatDraught,
+    boatWeight,
+    boatName,
+    boatModel,
+    nextButton,
+  } = berth.boatInformation;
+
+  await t.expect(heading.exists).ok();
+
+  await t
+    .typeText(boatRegistrationNumber, testData.boatRegistrationNumber)
+    .typeText(boatDraught, testData.boatDraught)
+    .typeText(boatWeight, testData.boatWeight)
+    .typeText(boatName, testData.boatName)
+    .typeText(boatModel, testData.boatModel);
+
+  await t.click(nextButton);
+};
+
+const applicantInformation = async (t: TestController) => {
+  const {
+    heading,
+    firstName,
+    lastName,
+    address,
+    postalCode,
+    municipalitySelect,
+    phoneNumber,
+    emailAddress,
+    nextButton,
+  } = berth.applicantInformation;
+
+  await t.expect(heading.exists).ok();
+
+  await t
+    .typeText(firstName, testData.firstName)
+    .typeText(lastName, testData.lastName)
+    .typeText(address, testData.address)
+    .typeText(postalCode, testData.postalCode)
+    .click(municipalitySelect)
+    .click(municipalitySelect.find('option').withText(testData.municipality))
+    .typeText(phoneNumber, testData.phoneNumber)
+    .typeText(emailAddress, testData.emailAddress);
+
+  await t.click(nextButton);
+};
+
+const overview = async (t: TestController) => {
+  const { heading, textInOverview, getLabelValuePairs } = berth.overview;
+
+  await t.expect(heading.exists).ok();
+
+  // Boat information
+  const labelValuePairs = await getLabelValuePairs();
+  const expectedContent = [
+    `Nimi: ${testData.boatName}`,
+    `Rekisterinumero: ${testData.boatRegistrationNumber}`,
+    `Tyyppi: ${testData.boatType}`,
+    `Malli: ${testData.boatModel}`,
+    `Leveys: ${testData.boatWidth}m`,
+    `Pituus: ${testData.boatLength}m`,
+    `Syväys: ${testData.boatDraught}m`,
+    `Paino: ${testData.boatWeight}`,
+  ].join('\n');
+  await t.expect(labelValuePairs).eql(expectedContent);
+
+  // Chosen harbors
+  await t
+    .expect(textInOverview(`1. ${testData.harbor2}`).exists)
+    .ok()
+    .expect(textInOverview(`2. ${testData.harbor1}`).exists)
+    .ok();
+
+  // Applicant
+  await t
+    .expect(textInOverview(testData.firstName).exists)
+    .ok()
+    .expect(textInOverview(testData.lastName).exists)
+    .ok()
+    .expect(textInOverview(testData.emailAddress).exists)
+    .ok()
+    .expect(textInOverview(testData.phoneNumber).exists)
+    .ok()
+    .expect(textInOverview(testData.address).exists)
+    .ok()
+    .expect(textInOverview(testData.postalCode).exists)
+    .ok()
+    .expect(textInOverview(testData.municipality).exists)
+    .ok();
+};

--- a/browser-tests/berth.ts
+++ b/browser-tests/berth.ts
@@ -1,6 +1,6 @@
-import berth from './selectors/berth';
-import navbar from './selectors/navbar';
-import shared from './selectors/shared';
+import { selectHarborsSelectors } from './selectors/berth';
+import { navbarSelectors } from './selectors/navbar';
+import { boatInformationSelectors } from './selectors/shared';
 import { isBerthsPage } from './utils/page';
 import { envUrl } from './utils/settings';
 import { applicantInformation, overview, yourSelection } from './utils/sharedTests';
@@ -29,7 +29,7 @@ const testData = {
 fixture('Berth').page(envUrl());
 
 test('New berth application, registered boat, private customer', async (t) => {
-  await t.click(navbar.berths);
+  await t.click(navbarSelectors.berths);
   await isBerthsPage();
 
   await selectHarbors(t);
@@ -59,7 +59,7 @@ const selectHarbors = async (t: TestController) => {
     harborListTab,
     nextButton,
     getSelectButtonForHarbor,
-  } = berth.selectHarbors;
+  } = selectHarborsSelectors;
 
   await t
     .click(boatTypeSelect)
@@ -89,7 +89,7 @@ const boatInformation = async (t: TestController) => {
     boatName,
     boatModel,
     nextButton,
-  } = shared.boatInformation;
+  } = boatInformationSelectors;
 
   await t.expect(heading.exists).ok();
 

--- a/browser-tests/frontPage.ts
+++ b/browser-tests/frontPage.ts
@@ -1,6 +1,6 @@
-import { footer } from './selectors/footer';
-import { frontPage } from './selectors/frontPage';
-import { navbar } from './selectors/navbar';
+import footer from './selectors/footer';
+import frontPage from './selectors/frontPage';
+import navbar from './selectors/navbar';
 import { navigateToFrontPage } from './utils/navigation';
 import { envUrl } from './utils/settings';
 import { switchToEnglish, switchToFinnish, switchToSwedish } from './utils/switchLanguage';

--- a/browser-tests/frontPage.ts
+++ b/browser-tests/frontPage.ts
@@ -1,6 +1,6 @@
-import footer from './selectors/footer';
-import frontPage from './selectors/frontPage';
-import navbar from './selectors/navbar';
+import { footerSelectors } from './selectors/footer';
+import { frontPageSelectors } from './selectors/frontPage';
+import { navbarSelectors } from './selectors/navbar';
 import { navigateToFrontPage } from './utils/navigation';
 import { envUrl } from './utils/settings';
 import { switchToEnglish, switchToFinnish, switchToSwedish } from './utils/switchLanguage';
@@ -14,74 +14,92 @@ import {
 fixture('Front page').page(envUrl());
 
 test('Navigation', async (t) => {
+  const { mainLink, berths, winterStorage, unmarkedWinterStorage } = navbarSelectors;
+
   // Main link
-  await t.click(navbar.mainLink);
+  await t.click(mainLink);
   await isFrontPage();
 
   // Berths
-  await t.click(navbar.berths);
+  await t.click(berths);
   await isBerthsPage();
 
   // Winter storage
-  await t.click(navbar.winterStorage);
+  await t.click(winterStorage);
   await isWinterStoragePage();
 
   // Unmarked winter storage
-  await t.click(navbar.unmarkedWinterStorage);
+  await t.click(unmarkedWinterStorage);
   await isUnmarkedWinterStoragePage();
 });
 
 test('Switching language', async (t) => {
+  const { languageSelect } = navbarSelectors;
+  const { title } = frontPageSelectors;
+
   // Switch to Swedish
-  await t.expect(navbar.languageSelect.Swedish.visible).notOk();
+  await t.expect(languageSelect.Swedish.visible).notOk();
   await switchToSwedish(t);
-  await t.expect(frontPage.title.innerText).eql('Båtplatser');
+  await t.expect(title.innerText).eql('Båtplatser');
 
   // Switch to English
-  await t.expect(navbar.languageSelect.English.visible).notOk();
+  await t.expect(languageSelect.English.visible).notOk();
   await switchToEnglish(t);
-  await t.expect(frontPage.title.innerText).eql('Boat berths');
+  await t.expect(title.innerText).eql('Boat berths');
 
   // Switch to Finnish
-  await t.expect(navbar.languageSelect.Finnish.visible).notOk();
+  await t.expect(languageSelect.Finnish.visible).notOk();
   await switchToFinnish(t);
-  await t.expect(frontPage.title.innerText).eql('Venepaikat');
+  await t.expect(title.innerText).eql('Venepaikat');
 });
 
 test('Front page links', async (t) => {
+  const { berths, winterStorage, unmarkedWinterStorage } = frontPageSelectors;
+
   // Berths
-  await t.click(frontPage.berths);
+  await t.click(berths);
   await isBerthsPage();
   await navigateToFrontPage();
 
   // Winter storage
-  await t.click(frontPage.winterStorage);
+  await t.click(winterStorage);
   await isWinterStoragePage();
   await navigateToFrontPage();
 
   // Unmarked winter storage
-  await t.click(frontPage.unmarkedWinterStorage);
+  await t.click(unmarkedWinterStorage);
   await isUnmarkedWinterStoragePage();
   await navigateToFrontPage();
 });
 
 test('Footer', async (t) => {
+  const {
+    serviceLink,
+    browseBerths,
+    boatingInformation,
+    recent,
+    privacyPolicy,
+    accessibilityPolicy,
+    sendFeedback,
+    contact,
+  } = footerSelectors;
+
   // 'Venepaikat' Link
-  await t.expect(footer.serviceLink.visible).ok();
+  await t.expect(serviceLink.visible).ok();
 
   // Link list
   await t
-    .expect(footer.browseBerths.visible)
+    .expect(browseBerths.visible)
     .ok()
-    .expect(footer.boatingInformation.visible)
+    .expect(boatingInformation.visible)
     .ok()
-    .expect(footer.recent.visible)
+    .expect(recent.visible)
     .ok()
-    .expect(footer.privacyPolicy.visible)
+    .expect(privacyPolicy.visible)
     .ok()
-    .expect(footer.accessibilityPolicy.visible)
+    .expect(accessibilityPolicy.visible)
     .ok();
 
   // Bottom links
-  await t.expect(footer.sendFeedback.visible).ok().expect(footer.contact.visible).ok();
+  await t.expect(sendFeedback.visible).ok().expect(contact.visible).ok();
 });

--- a/browser-tests/frontPage.ts
+++ b/browser-tests/frontPage.ts
@@ -1,0 +1,87 @@
+import { footer } from './selectors/footer';
+import { frontPage } from './selectors/frontPage';
+import { navbar } from './selectors/navbar';
+import { navigateToFrontPage } from './utils/navigation';
+import { envUrl } from './utils/settings';
+import { switchToEnglish, switchToFinnish, switchToSwedish } from './utils/switchLanguage';
+import {
+  isBerthsPage,
+  isFrontPage,
+  isUnmarkedWinterStoragePage,
+  isWinterStoragePage,
+} from './utils/page';
+
+fixture('Front page').page(envUrl());
+
+test('Navigation', async (t) => {
+  // Main link
+  await t.click(navbar.mainLink);
+  await isFrontPage();
+
+  // Berths
+  await t.click(navbar.berths);
+  await isBerthsPage();
+
+  // Winter storage
+  await t.click(navbar.winterStorage);
+  await isWinterStoragePage();
+
+  // Unmarked winter storage
+  await t.click(navbar.unmarkedWinterStorage);
+  await isUnmarkedWinterStoragePage();
+});
+
+test('Switching language', async (t) => {
+  // Switch to Swedish
+  await t.expect(navbar.languageSelect.Swedish.visible).notOk();
+  await switchToSwedish(t);
+  await t.expect(frontPage.title.innerText).eql('Båtplatser');
+
+  // Switch to English
+  await t.expect(navbar.languageSelect.English.visible).notOk();
+  await switchToEnglish(t);
+  await t.expect(frontPage.title.innerText).eql('Boat berths');
+
+  // Switch to Finnish
+  await t.expect(navbar.languageSelect.Finnish.visible).notOk();
+  await switchToFinnish(t);
+  await t.expect(frontPage.title.innerText).eql('Venepaikat');
+});
+
+test('Front page links', async (t) => {
+  // Berths
+  await t.click(frontPage.berths);
+  await isBerthsPage();
+  await navigateToFrontPage();
+
+  // Winter storage
+  await t.click(frontPage.winterStorage);
+  await isWinterStoragePage();
+  await navigateToFrontPage();
+
+  // Unmarked winter storage
+  await t.click(frontPage.unmarkedWinterStorage);
+  await isUnmarkedWinterStoragePage();
+  await navigateToFrontPage();
+});
+
+test('Footer', async (t) => {
+  // 'Venepaikat' Link
+  await t.expect(footer.serviceLink.visible).ok();
+
+  // Link list
+  await t
+    .expect(footer.browseBerths.visible)
+    .ok()
+    .expect(footer.boatingInformation.visible)
+    .ok()
+    .expect(footer.recent.visible)
+    .ok()
+    .expect(footer.privacyPolicy.visible)
+    .ok()
+    .expect(footer.accessibilityPolicy.visible)
+    .ok();
+
+  // Bottom links
+  await t.expect(footer.sendFeedback.visible).ok().expect(footer.contact.visible).ok();
+});

--- a/browser-tests/selectors/berth.ts
+++ b/browser-tests/selectors/berth.ts
@@ -1,6 +1,5 @@
 import { screen, within } from '@testing-library/testcafe';
 import { Selector } from 'testcafe';
-import { escapeRegExp } from 'lodash';
 
 const selectHarbors = {
   newApplicationRadio: screen.getByRole('radio', {
@@ -21,21 +20,6 @@ const selectHarbors = {
   },
 };
 
-const yourSelection = {
-  heading: screen.getByRole('heading', {
-    name: /omat valinnat/i,
-  }),
-  nextButton: screen.getByRole('button', { name: /jatka/i }),
-  getHarborHeading: (text: string) => {
-    const re = new RegExp(text, 'i');
-    return screen.getByText(re);
-  },
-  getUpButtonForHeading: (heading: Selector) => {
-    const row = heading.parent(2);
-    return within(row).getByRole('button', { name: /siirrä ylös/i });
-  },
-};
-
 const boatInformation = {
   heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
     name: /veneen tiedot/i,
@@ -52,49 +36,9 @@ const boatInformation = {
   nextButton: screen.getByRole('button', { name: /seuraava/i }),
 };
 
-const applicantInformation = {
-  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
-    name: /hakijan tiedot/i,
-  }),
-  firstName: screen.getByRole('textbox', { name: /etunimi/i }),
-  lastName: screen.getByRole('textbox', { name: /sukunimi/i }),
-  address: screen.getByRole('textbox', { name: /jakeluosoite/i }),
-  postalCode: screen.getByRole('textbox', { name: /postinumero/i }),
-  municipalitySelect: screen.getByRole('combobox', { name: /postitoimipaikka/i }),
-  phoneNumber: screen.getByRole('textbox', { name: /matkapuhelin/i }),
-  emailAddress: screen.getByRole('textbox', { name: /sähköpostiosoite/i }),
-  nextButton: screen.getByRole('button', { name: /seuraava/i }),
-};
-
-const overview = {
-  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
-    name: /yhteenveto/i,
-  }),
-  overviewInfo: Selector('div[class="vene-overview-info container"]'),
-  getLabelValuePairs: async () => {
-    const labelValuePairs = overview.overviewInfo.find('div[class="vene-label-value-pair"]');
-    const labelValuePairCount = await labelValuePairs.count;
-
-    const pairs: string[] = [];
-    for (let i = 0; i < labelValuePairCount; i += 1) {
-      const label = await labelValuePairs.nth(i).child(0).textContent;
-      // Skipping index 1 because it is just ':'
-      const value = await labelValuePairs.nth(i).child(2).textContent;
-      pairs.push(`${label}: ${value}`);
-    }
-    return pairs.join('\n');
-  },
-  textInOverview: (text: string) => {
-    return within(overview.overviewInfo).getByText(new RegExp(escapeRegExp(text)));
-  },
-};
-
 export const berth = {
   selectHarbors,
-  yourSelection,
   boatInformation,
-  applicantInformation,
-  overview,
   title: Selector('h1[class="vene-hero__title"]'),
   legend: Selector('div[class="vene-berths-legend"]'),
 };

--- a/browser-tests/selectors/berth.ts
+++ b/browser-tests/selectors/berth.ts
@@ -1,0 +1,100 @@
+import { screen, within } from '@testing-library/testcafe';
+import { Selector } from 'testcafe';
+import { escapeRegExp } from 'lodash';
+
+const selectHarbors = {
+  newApplicationRadio: screen.getByRole('radio', {
+    name: /uusi hakemus hakijalla ei ole vielä helsingin kaupungin tarjoamaa venepaikkaa/i,
+  }),
+  boatTypeSelect: screen.getByRole('combobox', { name: /veneen tyyppi/i }),
+  boatWidth: screen.getByRole('textbox', { name: /veneen leveys, m/i }),
+  boatLength: screen.getByRole('textbox', { name: /veneen pituus, m/i }),
+  wasteCollection: screen.getByRole('switch', { name: /jätehuolto/i }),
+  harborListTab: screen.getByRole('tab', { name: /lista/i }),
+  nextButton: screen.getByRole('button', { name: /seuraava/i }),
+  getSelectButtonForHarbor: (name: string) => {
+    const re = new RegExp(name, 'i');
+    const heading = screen.getByRole('heading', { name: re });
+    return within(heading.parent(0)).getByRole('button', {
+      name: /lisää valittuihin/i,
+    });
+  },
+};
+
+const yourSelection = {
+  heading: screen.getByRole('heading', {
+    name: /omat valinnat/i,
+  }),
+  nextButton: screen.getByRole('button', { name: /jatka/i }),
+  getHarborHeading: (text: string) => {
+    const re = new RegExp(text, 'i');
+    return screen.getByText(re);
+  },
+  getUpButtonForHeading: (heading: Selector) => {
+    const row = heading.parent(2);
+    return within(row).getByRole('button', { name: /siirrä ylös/i });
+  },
+};
+
+const boatInformation = {
+  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
+    name: /veneen tiedot/i,
+  }),
+  registeredBoat: screen.getByText(/rekisteröity vene/i),
+  boatRegistrationNumber: screen.getByRole('textbox', { name: /rekisterinumero/i }),
+  boatTypeSelect: screen.getByRole('combobox', { name: /veneen tyyppi/i }),
+  boatWidth: screen.getByRole('textbox', { name: /veneen leveys, m/i }),
+  boatLength: screen.getByRole('textbox', { name: /veneen pituus, m/i }),
+  boatDraught: screen.getByRole('textbox', { name: /veneen syväys, m/i }),
+  boatWeight: screen.getByRole('textbox', { name: /veneen paino, kg/i }),
+  boatName: screen.getByRole('textbox', { name: /nimi/i }),
+  boatModel: screen.getByRole('textbox', { name: /merkki/i }),
+  nextButton: screen.getByRole('button', { name: /seuraava/i }),
+};
+
+const applicantInformation = {
+  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
+    name: /hakijan tiedot/i,
+  }),
+  firstName: screen.getByRole('textbox', { name: /etunimi/i }),
+  lastName: screen.getByRole('textbox', { name: /sukunimi/i }),
+  address: screen.getByRole('textbox', { name: /jakeluosoite/i }),
+  postalCode: screen.getByRole('textbox', { name: /postinumero/i }),
+  municipalitySelect: screen.getByRole('combobox', { name: /postitoimipaikka/i }),
+  phoneNumber: screen.getByRole('textbox', { name: /matkapuhelin/i }),
+  emailAddress: screen.getByRole('textbox', { name: /sähköpostiosoite/i }),
+  nextButton: screen.getByRole('button', { name: /seuraava/i }),
+};
+
+const overview = {
+  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
+    name: /yhteenveto/i,
+  }),
+  overviewInfo: Selector('div[class="vene-overview-info container"]'),
+  getLabelValuePairs: async () => {
+    const labelValuePairs = overview.overviewInfo.find('div[class="vene-label-value-pair"]');
+    const labelValuePairCount = await labelValuePairs.count;
+
+    const pairs: string[] = [];
+    for (let i = 0; i < labelValuePairCount; i += 1) {
+      const label = await labelValuePairs.nth(i).child(0).textContent;
+      // Skipping index 1 because it is just ':'
+      const value = await labelValuePairs.nth(i).child(2).textContent;
+      pairs.push(`${label}: ${value}`);
+    }
+    return pairs.join('\n');
+  },
+  textInOverview: (text: string) => {
+    return within(overview.overviewInfo).getByText(new RegExp(escapeRegExp(text)));
+  },
+};
+
+export const berth = {
+  selectHarbors,
+  yourSelection,
+  boatInformation,
+  applicantInformation,
+  overview,
+  title: Selector('h1[class="vene-hero__title"]'),
+  legend: Selector('div[class="vene-berths-legend"]'),
+};

--- a/browser-tests/selectors/berth.ts
+++ b/browser-tests/selectors/berth.ts
@@ -20,25 +20,9 @@ const selectHarbors = {
   },
 };
 
-const boatInformation = {
-  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
-    name: /veneen tiedot/i,
-  }),
-  registeredBoat: screen.getByText(/rekisteröity vene/i),
-  boatRegistrationNumber: screen.getByRole('textbox', { name: /rekisterinumero/i }),
-  boatTypeSelect: screen.getByRole('combobox', { name: /veneen tyyppi/i }),
-  boatWidth: screen.getByRole('textbox', { name: /veneen leveys, m/i }),
-  boatLength: screen.getByRole('textbox', { name: /veneen pituus, m/i }),
-  boatDraught: screen.getByRole('textbox', { name: /veneen syväys, m/i }),
-  boatWeight: screen.getByRole('textbox', { name: /veneen paino, kg/i }),
-  boatName: screen.getByRole('textbox', { name: /nimi/i }),
-  boatModel: screen.getByRole('textbox', { name: /merkki/i }),
-  nextButton: screen.getByRole('button', { name: /seuraava/i }),
-};
-
-export const berth = {
+const berth = {
   selectHarbors,
-  boatInformation,
   title: Selector('h1[class="vene-hero__title"]'),
   legend: Selector('div[class="vene-berths-legend"]'),
 };
+export default berth;

--- a/browser-tests/selectors/berth.ts
+++ b/browser-tests/selectors/berth.ts
@@ -1,7 +1,7 @@
 import { screen, within } from '@testing-library/testcafe';
 import { Selector } from 'testcafe';
 
-const selectHarbors = {
+export const selectHarborsSelectors = {
   newApplicationRadio: screen.getByRole('radio', {
     name: /uusi hakemus hakijalla ei ole vielä helsingin kaupungin tarjoamaa venepaikkaa/i,
   }),
@@ -20,9 +20,7 @@ const selectHarbors = {
   },
 };
 
-const berth = {
-  selectHarbors,
+export const berthSelectors = {
   title: Selector('h1[class="vene-hero__title"]'),
   legend: Selector('div[class="vene-berths-legend"]'),
 };
-export default berth;

--- a/browser-tests/selectors/berths.ts
+++ b/browser-tests/selectors/berths.ts
@@ -1,0 +1,5 @@
+import { Selector } from 'testcafe';
+
+export const berths = {
+  title: Selector('h1[class="vene-hero__title"]'),
+};

--- a/browser-tests/selectors/berths.ts
+++ b/browser-tests/selectors/berths.ts
@@ -1,5 +1,0 @@
-import { Selector } from 'testcafe';
-
-export const berths = {
-  title: Selector('h1[class="vene-hero__title"]'),
-};

--- a/browser-tests/selectors/footer.ts
+++ b/browser-tests/selectors/footer.ts
@@ -1,0 +1,15 @@
+import { within } from '@testing-library/testcafe';
+import { Selector } from 'testcafe';
+
+const element = Selector('div[class="vene-footer"]');
+
+export const footer = {
+  serviceLink: within(element).getByText('Venepaikat'),
+  browseBerths: within(element).getByText('Selaa venesatamia'),
+  boatingInformation: within(element).getByText('Veneilytietoa'),
+  recent: within(element).getByText('Ajankohtaista'),
+  privacyPolicy: within(element).getByText('Rekisteriseloste'),
+  accessibilityPolicy: within(element).getByText('Saavutettavuusseloste'),
+  sendFeedback: within(element).getByText('Lähetä palautetta'),
+  contact: within(element).getByText('Ota yhteyttä'),
+};

--- a/browser-tests/selectors/footer.ts
+++ b/browser-tests/selectors/footer.ts
@@ -3,7 +3,7 @@ import { Selector } from 'testcafe';
 
 const element = Selector('div[class="vene-footer"]');
 
-const footer = {
+export const footerSelectors = {
   serviceLink: within(element).getByText('Venepaikat'),
   browseBerths: within(element).getByText('Selaa venesatamia'),
   boatingInformation: within(element).getByText('Veneilytietoa'),
@@ -13,4 +13,3 @@ const footer = {
   sendFeedback: within(element).getByText('Lähetä palautetta'),
   contact: within(element).getByText('Ota yhteyttä'),
 };
-export default footer;

--- a/browser-tests/selectors/footer.ts
+++ b/browser-tests/selectors/footer.ts
@@ -3,7 +3,7 @@ import { Selector } from 'testcafe';
 
 const element = Selector('div[class="vene-footer"]');
 
-export const footer = {
+const footer = {
   serviceLink: within(element).getByText('Venepaikat'),
   browseBerths: within(element).getByText('Selaa venesatamia'),
   boatingInformation: within(element).getByText('Veneilytietoa'),
@@ -13,3 +13,4 @@ export const footer = {
   sendFeedback: within(element).getByText('Lähetä palautetta'),
   contact: within(element).getByText('Ota yhteyttä'),
 };
+export default footer;

--- a/browser-tests/selectors/frontPage.ts
+++ b/browser-tests/selectors/frontPage.ts
@@ -3,10 +3,9 @@ import { Selector } from 'testcafe';
 
 const content = Selector('div[class="vene-front-page container"]');
 
-const frontPage = {
+export const frontPageSelectors = {
   title: Selector('h1[class="vene-hero__title"]'),
   berths: within(content).getByText('Selaa ja hae venepaikkoja'),
   winterStorage: within(content).getByText('Selaa ja hae talvisäilytyspaikkoja'),
   unmarkedWinterStorage: within(content).getByText('Ilmoita'),
 };
-export default frontPage;

--- a/browser-tests/selectors/frontPage.ts
+++ b/browser-tests/selectors/frontPage.ts
@@ -1,0 +1,11 @@
+import { within } from '@testing-library/testcafe';
+import { Selector } from 'testcafe';
+
+const content = Selector('div[class="vene-front-page container"]');
+
+export const frontPage = {
+  title: Selector('h1[class="vene-hero__title"]'),
+  berths: within(content).getByText('Selaa ja hae venepaikkoja'),
+  winterStorage: within(content).getByText('Selaa ja hae talvisäilytyspaikkoja'),
+  unmarkedWinterStorage: within(content).getByText('Ilmoita'),
+};

--- a/browser-tests/selectors/frontPage.ts
+++ b/browser-tests/selectors/frontPage.ts
@@ -3,9 +3,10 @@ import { Selector } from 'testcafe';
 
 const content = Selector('div[class="vene-front-page container"]');
 
-export const frontPage = {
+const frontPage = {
   title: Selector('h1[class="vene-hero__title"]'),
   berths: within(content).getByText('Selaa ja hae venepaikkoja'),
   winterStorage: within(content).getByText('Selaa ja hae talvisäilytyspaikkoja'),
   unmarkedWinterStorage: within(content).getByText('Ilmoita'),
 };
+export default frontPage;

--- a/browser-tests/selectors/navbar.ts
+++ b/browser-tests/selectors/navbar.ts
@@ -4,7 +4,7 @@ import { Selector } from 'testcafe';
 const element = Selector('div[class="vene-navbar"]');
 const languageSelect = element.find('div[class^="vene-language-dropdown"]');
 
-export const navbar = {
+const navbar = {
   mainLink: within(element).getByText('Venepaikat'),
   berths: within(element).getByText('Venepaikkahaku'),
   winterStorage: within(element).getByText('Talvisäilytyspaikat'),
@@ -16,3 +16,4 @@ export const navbar = {
     English: within(element).getByText('In English'),
   },
 };
+export default navbar;

--- a/browser-tests/selectors/navbar.ts
+++ b/browser-tests/selectors/navbar.ts
@@ -1,0 +1,18 @@
+import { within } from '@testing-library/testcafe';
+import { Selector } from 'testcafe';
+
+const element = Selector('div[class="vene-navbar"]');
+const languageSelect = element.find('div[class^="vene-language-dropdown"]');
+
+export const navbar = {
+  mainLink: within(element).getByText('Venepaikat'),
+  berths: within(element).getByText('Venepaikkahaku'),
+  winterStorage: within(element).getByText('Talvisäilytyspaikat'),
+  unmarkedWinterStorage: within(element).getByText('Nostojärjestysilmoitus'),
+  languageSelect: {
+    button: languageSelect.find('button'),
+    Finnish: within(element).getByText('Suomeksi'),
+    Swedish: within(element).getByText('På svenska'),
+    English: within(element).getByText('In English'),
+  },
+};

--- a/browser-tests/selectors/navbar.ts
+++ b/browser-tests/selectors/navbar.ts
@@ -4,7 +4,7 @@ import { Selector } from 'testcafe';
 const element = Selector('div[class="vene-navbar"]');
 const languageSelect = element.find('div[class^="vene-language-dropdown"]');
 
-const navbar = {
+export const navbarSelectors = {
   mainLink: within(element).getByText('Venepaikat'),
   berths: within(element).getByText('Venepaikkahaku'),
   winterStorage: within(element).getByText('Talvisäilytyspaikat'),
@@ -16,4 +16,3 @@ const navbar = {
     English: within(element).getByText('In English'),
   },
 };
-export default navbar;

--- a/browser-tests/selectors/shared.ts
+++ b/browser-tests/selectors/shared.ts
@@ -2,7 +2,7 @@ import { screen, within } from '@testing-library/testcafe';
 import { escapeRegExp } from 'lodash';
 import { Selector } from 'testcafe';
 
-const yourSelection = {
+export const yourSelectionSelectors = {
   heading: screen.getByRole('heading', {
     name: /omat valinnat/i,
   }),
@@ -17,7 +17,7 @@ const yourSelection = {
   },
 };
 
-const applicantInformation = {
+export const applicantInformationSelectors = {
   heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
     name: /hakijan tiedot/i,
   }),
@@ -31,13 +31,15 @@ const applicantInformation = {
   nextButton: screen.getByRole('button', { name: /seuraava/i }),
 };
 
-const overview = {
+export const overviewSelectors = {
   heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
     name: /yhteenveto/i,
   }),
   overviewInfo: Selector('div[class="vene-overview-info container"]'),
   getLabelValuePairs: async () => {
-    const labelValuePairs = overview.overviewInfo.find('div[class="vene-label-value-pair"]');
+    const labelValuePairs = overviewSelectors.overviewInfo.find(
+      'div[class="vene-label-value-pair"]'
+    );
     const labelValuePairCount = await labelValuePairs.count;
 
     const pairs: string[] = [];
@@ -50,11 +52,11 @@ const overview = {
     return pairs.join('\n');
   },
   textInOverview: (text: string) => {
-    return within(overview.overviewInfo).getByText(new RegExp(escapeRegExp(text)));
+    return within(overviewSelectors.overviewInfo).getByText(new RegExp(escapeRegExp(text)));
   },
 };
 
-const boatInformation = {
+export const boatInformationSelectors = {
   boatDraught: screen.getByRole('textbox', { name: /veneen syväys, m/i }),
   boatLength: screen.getByRole('textbox', { name: /veneen pituus, m/i }),
   boatModel: screen.getByRole('textbox', { name: /merkki/i }),
@@ -71,11 +73,3 @@ const boatInformation = {
   registeredBoat: screen.getByText(/rekisteröity vene/i),
   trailerRegistrationNumber: screen.getByRole('textbox', { name: /trailerin rekisterinumero/i }),
 };
-
-const shared = {
-  yourSelection,
-  applicantInformation,
-  overview,
-  boatInformation,
-};
-export default shared;

--- a/browser-tests/selectors/shared.ts
+++ b/browser-tests/selectors/shared.ts
@@ -2,7 +2,7 @@ import { screen, within } from '@testing-library/testcafe';
 import { escapeRegExp } from 'lodash';
 import { Selector } from 'testcafe';
 
-export const yourSelection = {
+const yourSelection = {
   heading: screen.getByRole('heading', {
     name: /omat valinnat/i,
   }),
@@ -17,7 +17,7 @@ export const yourSelection = {
   },
 };
 
-export const applicantInformation = {
+const applicantInformation = {
   heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
     name: /hakijan tiedot/i,
   }),
@@ -31,7 +31,7 @@ export const applicantInformation = {
   nextButton: screen.getByRole('button', { name: /seuraava/i }),
 };
 
-export const overview = {
+const overview = {
   heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
     name: /yhteenveto/i,
   }),
@@ -53,3 +53,29 @@ export const overview = {
     return within(overview.overviewInfo).getByText(new RegExp(escapeRegExp(text)));
   },
 };
+
+const boatInformation = {
+  boatDraught: screen.getByRole('textbox', { name: /veneen syväys, m/i }),
+  boatLength: screen.getByRole('textbox', { name: /veneen pituus, m/i }),
+  boatModel: screen.getByRole('textbox', { name: /merkki/i }),
+  boatName: screen.getByRole('textbox', { name: /nimi/i }),
+  boatRegistrationNumber: screen.getByRole('textbox', { name: 'Rekisterinumero' }),
+  boatStoredOnTrailer: screen.getByRole('radio', { name: /säilytän veneen trailerilla/i }),
+  boatTypeSelect: screen.getByRole('combobox', { name: /veneen tyyppi/i }),
+  boatWeight: screen.getByRole('textbox', { name: /veneen paino, kg/i }),
+  boatWidth: screen.getByRole('textbox', { name: /veneen leveys, m/i }),
+  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
+    name: /veneen tiedot/i,
+  }),
+  nextButton: screen.getByRole('button', { name: /seuraava/i }),
+  registeredBoat: screen.getByText(/rekisteröity vene/i),
+  trailerRegistrationNumber: screen.getByRole('textbox', { name: /trailerin rekisterinumero/i }),
+};
+
+const shared = {
+  yourSelection,
+  applicantInformation,
+  overview,
+  boatInformation,
+};
+export default shared;

--- a/browser-tests/selectors/shared.ts
+++ b/browser-tests/selectors/shared.ts
@@ -1,0 +1,55 @@
+import { screen, within } from '@testing-library/testcafe';
+import { escapeRegExp } from 'lodash';
+import { Selector } from 'testcafe';
+
+export const yourSelection = {
+  heading: screen.getByRole('heading', {
+    name: /omat valinnat/i,
+  }),
+  nextButton: screen.getByRole('button', { name: /jatka/i }),
+  getHarborHeading: (text: string) => {
+    const re = new RegExp(text, 'i');
+    return screen.getByText(re);
+  },
+  getUpButtonForHeading: (heading: Selector) => {
+    const row = heading.parent(2);
+    return within(row).getByRole('button', { name: /siirrä ylös/i });
+  },
+};
+
+export const applicantInformation = {
+  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
+    name: /hakijan tiedot/i,
+  }),
+  firstName: screen.getByRole('textbox', { name: /etunimi/i }),
+  lastName: screen.getByRole('textbox', { name: /sukunimi/i }),
+  address: screen.getByRole('textbox', { name: /jakeluosoite/i }),
+  postalCode: screen.getByRole('textbox', { name: /postinumero/i }),
+  municipalitySelect: screen.getByRole('combobox', { name: /postitoimipaikka/i }),
+  phoneNumber: screen.getByRole('textbox', { name: /matkapuhelin/i }),
+  emailAddress: screen.getByRole('textbox', { name: /sähköpostiosoite/i }),
+  nextButton: screen.getByRole('button', { name: /seuraava/i }),
+};
+
+export const overview = {
+  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
+    name: /yhteenveto/i,
+  }),
+  overviewInfo: Selector('div[class="vene-overview-info container"]'),
+  getLabelValuePairs: async () => {
+    const labelValuePairs = overview.overviewInfo.find('div[class="vene-label-value-pair"]');
+    const labelValuePairCount = await labelValuePairs.count;
+
+    const pairs: string[] = [];
+    for (let i = 0; i < labelValuePairCount; i += 1) {
+      const label = await labelValuePairs.nth(i).child(0).textContent;
+      // Skipping index 1 because it is just ':'
+      const value = await labelValuePairs.nth(i).child(2).textContent;
+      pairs.push(`${label}: ${value}`);
+    }
+    return pairs.join('\n');
+  },
+  textInOverview: (text: string) => {
+    return within(overview.overviewInfo).getByText(new RegExp(escapeRegExp(text)));
+  },
+};

--- a/browser-tests/selectors/unmarkedWinterStorage.ts
+++ b/browser-tests/selectors/unmarkedWinterStorage.ts
@@ -1,5 +1,6 @@
 import { Selector } from 'testcafe';
 
-export const unmarkedWinterStorage = {
+const unmarkedWinterStorage = {
   title: Selector('h1[class="vene-hero__title"]'),
 };
+export default unmarkedWinterStorage;

--- a/browser-tests/selectors/unmarkedWinterStorage.ts
+++ b/browser-tests/selectors/unmarkedWinterStorage.ts
@@ -1,6 +1,35 @@
+import { screen, within } from '@testing-library/testcafe';
 import { Selector } from 'testcafe';
 
+const areaSelection = {
+  winterStorageAreaSelect: screen.getByRole('combobox', { name: /talvisäilytysalue/i }),
+  continueButton: screen.getByRole('button', { name: /jatka/i }),
+};
+
+const boatInformation = {
+  boatLength: screen.getByRole('textbox', { name: /veneen pituus, m/i }),
+  boatModel: screen.getByRole('textbox', { name: /merkki/i }),
+  boatName: screen.getByRole('textbox', { name: /nimi/i }),
+  boatRegistrationNumber: screen.getByRole('textbox', { name: 'Rekisterinumero' }),
+  boatStoredOnTrailer: screen.getByRole('radio', { name: /säilytän veneen trailerilla/i }),
+  boatTypeSelect: screen.getByRole('combobox', { name: /veneen tyyppi/i }),
+  boatWidth: screen.getByRole('textbox', { name: /veneen leveys, m/i }),
+  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
+    name: /veneen tiedot/i,
+  }),
+  nextButton: screen.getByRole('button', { name: /seuraava/i }),
+  trailerRegistrationNumber: screen.getByRole('textbox', { name: /trailerin rekisterinumero/i }),
+};
+
 const unmarkedWinterStorage = {
+  areaSelection,
+  boatInformation,
+  ownerInformationHeading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
+    name: /omistajan tiedot/i,
+  }),
+  confirmationHeading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
+    name: /tarkista ilmoitus/i,
+  }),
   title: Selector('h1[class="vene-hero__title"]'),
 };
 export default unmarkedWinterStorage;

--- a/browser-tests/selectors/unmarkedWinterStorage.ts
+++ b/browser-tests/selectors/unmarkedWinterStorage.ts
@@ -1,12 +1,12 @@
 import { screen, within } from '@testing-library/testcafe';
 import { Selector } from 'testcafe';
 
-const areaSelection = {
+export const areaSelectionSelectors = {
   winterStorageAreaSelect: screen.getByRole('combobox', { name: /talvisäilytysalue/i }),
   continueButton: screen.getByRole('button', { name: /jatka/i }),
 };
 
-const boatInformation = {
+export const boatInformationSelectors = {
   boatLength: screen.getByRole('textbox', { name: /veneen pituus, m/i }),
   boatModel: screen.getByRole('textbox', { name: /merkki/i }),
   boatName: screen.getByRole('textbox', { name: /nimi/i }),
@@ -21,9 +21,7 @@ const boatInformation = {
   trailerRegistrationNumber: screen.getByRole('textbox', { name: /trailerin rekisterinumero/i }),
 };
 
-const unmarkedWinterStorage = {
-  areaSelection,
-  boatInformation,
+export const unmarkedWinterStorageSelectors = {
   ownerInformationHeading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
     name: /omistajan tiedot/i,
   }),
@@ -32,4 +30,3 @@ const unmarkedWinterStorage = {
   }),
   title: Selector('h1[class="vene-hero__title"]'),
 };
-export default unmarkedWinterStorage;

--- a/browser-tests/selectors/unmarkedWinterStorage.ts
+++ b/browser-tests/selectors/unmarkedWinterStorage.ts
@@ -1,0 +1,5 @@
+import { Selector } from 'testcafe';
+
+export const unmarkedWinterStorage = {
+  title: Selector('h1[class="vene-hero__title"]'),
+};

--- a/browser-tests/selectors/winterStorage.ts
+++ b/browser-tests/selectors/winterStorage.ts
@@ -1,7 +1,7 @@
 import { screen, within } from '@testing-library/testcafe';
 import { Selector } from 'testcafe';
 
-const selectAreas = {
+export const selectAreasSelectors = {
   boatWidth: screen.getByRole('textbox', { name: /veneen leveys, m/i }),
   boatLength: screen.getByRole('textbox', { name: /veneen pituus, m/i }),
   boatStoredOnTrailer: screen.getByRole('checkbox', { name: /vene säilytetään trailerilla/i }),
@@ -17,8 +17,6 @@ const selectAreas = {
   },
 };
 
-const winterStorage = {
-  selectAreas,
+export const winterStorageSelectors = {
   title: Selector('h1[class="vene-hero__title"]'),
 };
-export default winterStorage;

--- a/browser-tests/selectors/winterStorage.ts
+++ b/browser-tests/selectors/winterStorage.ts
@@ -1,5 +1,4 @@
 import { screen, within } from '@testing-library/testcafe';
-import { escapeRegExp } from 'lodash';
 import { Selector } from 'testcafe';
 
 const selectAreas = {
@@ -18,21 +17,6 @@ const selectAreas = {
   },
 };
 
-const yourSelection = {
-  heading: screen.getByRole('heading', {
-    name: /omat valinnat/i,
-  }),
-  nextButton: screen.getByRole('button', { name: /jatka/i }),
-  getHarborHeading: (text: string) => {
-    const re = new RegExp(text, 'i');
-    return screen.getByText(re);
-  },
-  getUpButtonForHeading: (heading: Selector) => {
-    const row = heading.parent(2);
-    return within(row).getByRole('button', { name: /siirrä ylös/i });
-  },
-};
-
 const boatInformation = {
   boatLength: screen.getByRole('textbox', { name: /veneen pituus, m/i }),
   boatModel: screen.getByRole('textbox', { name: /merkki/i }),
@@ -48,48 +32,8 @@ const boatInformation = {
   trailerRegistrationNumber: screen.getByRole('textbox', { name: /trailerin rekisterinumero/i }),
 };
 
-const applicantInformation = {
-  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
-    name: /hakijan tiedot/i,
-  }),
-  firstName: screen.getByRole('textbox', { name: /etunimi/i }),
-  lastName: screen.getByRole('textbox', { name: /sukunimi/i }),
-  address: screen.getByRole('textbox', { name: /jakeluosoite/i }),
-  postalCode: screen.getByRole('textbox', { name: /postinumero/i }),
-  municipalitySelect: screen.getByRole('combobox', { name: /postitoimipaikka/i }),
-  phoneNumber: screen.getByRole('textbox', { name: /matkapuhelin/i }),
-  emailAddress: screen.getByRole('textbox', { name: /sähköpostiosoite/i }),
-  nextButton: screen.getByRole('button', { name: /seuraava/i }),
-};
-
-const overview = {
-  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
-    name: /yhteenveto/i,
-  }),
-  overviewInfo: Selector('div[class="vene-overview-info container"]'),
-  getLabelValuePairs: async () => {
-    const labelValuePairs = overview.overviewInfo.find('div[class="vene-label-value-pair"]');
-    const labelValuePairCount = await labelValuePairs.count;
-
-    const pairs: string[] = [];
-    for (let i = 0; i < labelValuePairCount; i += 1) {
-      const label = await labelValuePairs.nth(i).child(0).textContent;
-      // Skipping index 1 because it is just ':'
-      const value = await labelValuePairs.nth(i).child(2).textContent;
-      pairs.push(`${label}: ${value}`);
-    }
-    return pairs.join('\n');
-  },
-  textInOverview: (text: string) => {
-    return within(overview.overviewInfo).getByText(new RegExp(escapeRegExp(text)));
-  },
-};
-
 export const winterStorage = {
   selectAreas,
-  yourSelection,
   boatInformation,
-  applicantInformation,
-  overview,
   title: Selector('h1[class="vene-hero__title"]'),
 };

--- a/browser-tests/selectors/winterStorage.ts
+++ b/browser-tests/selectors/winterStorage.ts
@@ -1,0 +1,5 @@
+import { Selector } from 'testcafe';
+
+export const winterStorage = {
+  title: Selector('h1[class="vene-hero__title"]'),
+};

--- a/browser-tests/selectors/winterStorage.ts
+++ b/browser-tests/selectors/winterStorage.ts
@@ -17,23 +17,8 @@ const selectAreas = {
   },
 };
 
-const boatInformation = {
-  boatLength: screen.getByRole('textbox', { name: /veneen pituus, m/i }),
-  boatModel: screen.getByRole('textbox', { name: /merkki/i }),
-  boatName: screen.getByRole('textbox', { name: /nimi/i }),
-  boatRegistrationNumber: screen.getByRole('textbox', { name: 'Rekisterinumero' }),
-  boatStoredOnTrailer: screen.getByRole('radio', { name: /säilytän veneen trailerilla/i }),
-  boatTypeSelect: screen.getByRole('combobox', { name: /veneen tyyppi/i }),
-  boatWidth: screen.getByRole('textbox', { name: /veneen leveys, m/i }),
-  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
-    name: /veneen tiedot/i,
-  }),
-  nextButton: screen.getByRole('button', { name: /seuraava/i }),
-  trailerRegistrationNumber: screen.getByRole('textbox', { name: /trailerin rekisterinumero/i }),
-};
-
-export const winterStorage = {
+const winterStorage = {
   selectAreas,
-  boatInformation,
   title: Selector('h1[class="vene-hero__title"]'),
 };
+export default winterStorage;

--- a/browser-tests/selectors/winterStorage.ts
+++ b/browser-tests/selectors/winterStorage.ts
@@ -1,5 +1,95 @@
+import { screen, within } from '@testing-library/testcafe';
+import { escapeRegExp } from 'lodash';
 import { Selector } from 'testcafe';
 
+const selectAreas = {
+  boatWidth: screen.getByRole('textbox', { name: /veneen leveys, m/i }),
+  boatLength: screen.getByRole('textbox', { name: /veneen pituus, m/i }),
+  boatStoredOnTrailer: screen.getByRole('checkbox', { name: /vene säilytetään trailerilla/i }),
+  electricity: screen.getByRole('button', { name: /sähkö/i }),
+  harborListTab: screen.getByRole('tab', { name: /lista/i }),
+  nextButton: screen.getByRole('button', { name: /seuraava/i }),
+  getSelectButtonForArea: (name: string) => {
+    const re = new RegExp(name, 'i');
+    const heading = screen.getByRole('heading', { name: re });
+    return within(heading.parent(0)).getByRole('button', {
+      name: /lisää valittuihin/i,
+    });
+  },
+};
+
+const yourSelection = {
+  heading: screen.getByRole('heading', {
+    name: /omat valinnat/i,
+  }),
+  nextButton: screen.getByRole('button', { name: /jatka/i }),
+  getHarborHeading: (text: string) => {
+    const re = new RegExp(text, 'i');
+    return screen.getByText(re);
+  },
+  getUpButtonForHeading: (heading: Selector) => {
+    const row = heading.parent(2);
+    return within(row).getByRole('button', { name: /siirrä ylös/i });
+  },
+};
+
+const boatInformation = {
+  boatLength: screen.getByRole('textbox', { name: /veneen pituus, m/i }),
+  boatModel: screen.getByRole('textbox', { name: /merkki/i }),
+  boatName: screen.getByRole('textbox', { name: /nimi/i }),
+  boatRegistrationNumber: screen.getByRole('textbox', { name: 'Rekisterinumero' }),
+  boatStoredOnTrailer: screen.getByRole('radio', { name: /säilytän veneen trailerilla/i }),
+  boatTypeSelect: screen.getByRole('combobox', { name: /veneen tyyppi/i }),
+  boatWidth: screen.getByRole('textbox', { name: /veneen leveys, m/i }),
+  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
+    name: /veneen tiedot/i,
+  }),
+  nextButton: screen.getByRole('button', { name: /seuraava/i }),
+  trailerRegistrationNumber: screen.getByRole('textbox', { name: /trailerin rekisterinumero/i }),
+};
+
+const applicantInformation = {
+  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
+    name: /hakijan tiedot/i,
+  }),
+  firstName: screen.getByRole('textbox', { name: /etunimi/i }),
+  lastName: screen.getByRole('textbox', { name: /sukunimi/i }),
+  address: screen.getByRole('textbox', { name: /jakeluosoite/i }),
+  postalCode: screen.getByRole('textbox', { name: /postinumero/i }),
+  municipalitySelect: screen.getByRole('combobox', { name: /postitoimipaikka/i }),
+  phoneNumber: screen.getByRole('textbox', { name: /matkapuhelin/i }),
+  emailAddress: screen.getByRole('textbox', { name: /sähköpostiosoite/i }),
+  nextButton: screen.getByRole('button', { name: /seuraava/i }),
+};
+
+const overview = {
+  heading: within(Selector('div[class="vene-form-legend"]')).getByRole('heading', {
+    name: /yhteenveto/i,
+  }),
+  overviewInfo: Selector('div[class="vene-overview-info container"]'),
+  getLabelValuePairs: async () => {
+    const labelValuePairs = overview.overviewInfo.find('div[class="vene-label-value-pair"]');
+    const labelValuePairCount = await labelValuePairs.count;
+
+    const pairs: string[] = [];
+    for (let i = 0; i < labelValuePairCount; i += 1) {
+      const label = await labelValuePairs.nth(i).child(0).textContent;
+      // Skipping index 1 because it is just ':'
+      const value = await labelValuePairs.nth(i).child(2).textContent;
+      pairs.push(`${label}: ${value}`);
+    }
+    return pairs.join('\n');
+  },
+  textInOverview: (text: string) => {
+    return within(overview.overviewInfo).getByText(new RegExp(escapeRegExp(text)));
+  },
+};
+
 export const winterStorage = {
+  selectAreas,
+  yourSelection,
+  boatInformation,
+  applicantInformation,
+  overview,
   title: Selector('h1[class="vene-hero__title"]'),
 };

--- a/browser-tests/sharedTests/sharedTests.ts
+++ b/browser-tests/sharedTests/sharedTests.ts
@@ -4,11 +4,9 @@ import {
   overviewSelectors,
   yourSelectionSelectors,
 } from '../selectors/shared';
+import { ApplicantInformation, Choices, WsBoatInformation } from '../types/types';
 
-export const swapSelections = async (
-  t: TestController,
-  testData: { choice2: string; choice1: string }
-) => {
+export const swapSelections = async (t: TestController, testData: Choices) => {
   const { heading, getHarborHeading, getUpButtonForHeading, nextButton } = yourSelectionSelectors;
 
   await t.expect(heading.exists).ok();
@@ -24,19 +22,7 @@ export const swapSelections = async (
   await t.click(nextButton);
 };
 
-export const fillWsBoatInformation = async (
-  t: TestController,
-  testData: {
-    boatLength: string;
-    boatModel: string;
-    boatName: string;
-    boatRegistrationNumber: string;
-    boatType: string;
-    boatTypeIndex: string | undefined;
-    boatWidth: string;
-    trailerRegistrationNumber: string;
-  }
-) => {
+export const fillWsBoatInformation = async (t: TestController, testData: WsBoatInformation) => {
   const {
     boatLength,
     boatModel,
@@ -74,15 +60,7 @@ export const fillWsBoatInformation = async (
 
 export const fillApplicantInformation = async (
   t: TestController,
-  testData: {
-    firstName: string;
-    lastName: string;
-    address: string;
-    postalCode: string;
-    municipality: string;
-    phoneNumber: string;
-    emailAddress: string;
-  },
+  testData: ApplicantInformation,
   skipHeadingCheck = false
 ) => {
   const {
@@ -116,17 +94,7 @@ export const fillApplicantInformation = async (
 
 export const assertOverview = async (
   t: TestController,
-  testData: {
-    address: string;
-    choice1: any;
-    choice2: any;
-    emailAddress: string;
-    firstName: string;
-    lastName: string;
-    municipality: string;
-    phoneNumber: string;
-    postalCode: string;
-  },
+  testData: Choices & ApplicantInformation,
   expectedBoatInfo: string
 ) => {
   const { heading, textInOverview, getLabelValuePairs } = overviewSelectors;

--- a/browser-tests/sharedTests/sharedTests.ts
+++ b/browser-tests/sharedTests/sharedTests.ts
@@ -5,7 +5,7 @@ import {
   yourSelectionSelectors,
 } from '../selectors/shared';
 
-export const yourSelection = async (
+export const swapSelections = async (
   t: TestController,
   testData: { choice2: string; choice1: string }
 ) => {
@@ -24,7 +24,7 @@ export const yourSelection = async (
   await t.click(nextButton);
 };
 
-export const wsBoatInformation = async (
+export const fillWsBoatInformation = async (
   t: TestController,
   testData: {
     boatLength: string;
@@ -72,7 +72,7 @@ export const wsBoatInformation = async (
   await t.click(nextButton);
 };
 
-export const applicantInformation = async (
+export const fillApplicantInformation = async (
   t: TestController,
   testData: {
     firstName: string;
@@ -114,7 +114,7 @@ export const applicantInformation = async (
   await t.click(nextButton);
 };
 
-export const overview = async (
+export const assertOverview = async (
   t: TestController,
   testData: {
     address: string;
@@ -145,10 +145,10 @@ export const overview = async (
     .ok();
 
   // Applicant
-  await applicantOverview(t, testData);
+  await fillApplicantOverview(t, testData);
 };
 
-export const applicantOverview = (
+export const fillApplicantOverview = (
   t: TestController,
   testData: {
     firstName: string;

--- a/browser-tests/types/types.ts
+++ b/browser-tests/types/types.ts
@@ -1,0 +1,38 @@
+export type Choices = {
+  choice1: string;
+  choice2: string;
+};
+
+export type UnmarkedWinterStorageChoice = {
+  winterStorageArea: string;
+  winterStorageAreaIndex: number;
+};
+
+type BoatInformation = {
+  boatLength: string;
+  boatModel: string;
+  boatName: string;
+  boatRegistrationNumber: string;
+  boatType: string;
+  boatTypeIndex: string;
+  boatWidth: string;
+};
+
+export type BerthBoatInformation = BoatInformation & {
+  boatDraught: string;
+  boatWeight: string;
+};
+
+export type WsBoatInformation = BoatInformation & {
+  trailerRegistrationNumber: string;
+};
+
+export type ApplicantInformation = {
+  firstName: string;
+  lastName: string;
+  address: string;
+  postalCode: string;
+  municipality: string;
+  phoneNumber: string;
+  emailAddress: string;
+};

--- a/browser-tests/unmarkedWinterStorage.ts
+++ b/browser-tests/unmarkedWinterStorage.ts
@@ -1,6 +1,9 @@
-import navbar from './selectors/navbar';
-import shared from './selectors/shared';
-import unmarkedWinterStorage from './selectors/unmarkedWinterStorage';
+import { navbarSelectors } from './selectors/navbar';
+import { overviewSelectors } from './selectors/shared';
+import {
+  areaSelectionSelectors,
+  unmarkedWinterStorageSelectors,
+} from './selectors/unmarkedWinterStorage';
 import { isUnmarkedWinterStoragePage } from './utils/page';
 import { envUrl } from './utils/settings';
 import { applicantInformation, applicantOverview, wsBoatInformation } from './utils/sharedTests';
@@ -28,13 +31,13 @@ const testData = {
 fixture('Unmarked winter storage').page(envUrl());
 
 test('Unmarked winter storage notice, registered boat on trailer, private customer', async (t) => {
-  await t.click(navbar.unmarkedWinterStorage);
+  await t.click(navbarSelectors.unmarkedWinterStorage);
   await isUnmarkedWinterStoragePage();
 
   await areaSelection(t);
   await wsBoatInformation(t, testData);
 
-  await t.expect(unmarkedWinterStorage.ownerInformationHeading.exists).ok();
+  await t.expect(unmarkedWinterStorageSelectors.ownerInformationHeading.exists).ok();
   await applicantInformation(t, testData, true);
 
   const expectedBoatInfo = [
@@ -51,7 +54,7 @@ test('Unmarked winter storage notice, registered boat on trailer, private custom
 });
 
 const areaSelection = async (t: TestController) => {
-  const { winterStorageAreaSelect, continueButton } = unmarkedWinterStorage.areaSelection;
+  const { winterStorageAreaSelect, continueButton } = areaSelectionSelectors;
 
   await t
     .click(winterStorageAreaSelect)
@@ -61,9 +64,9 @@ const areaSelection = async (t: TestController) => {
 };
 
 const confirmation = async (t: TestController, expectedBoatInfo: string) => {
-  const { textInOverview, getLabelValuePairs } = shared.overview;
+  const { textInOverview, getLabelValuePairs } = overviewSelectors;
 
-  await t.expect(unmarkedWinterStorage.confirmationHeading.exists).ok();
+  await t.expect(unmarkedWinterStorageSelectors.confirmationHeading.exists).ok();
 
   // Boat information
   const labelValuePairs = await getLabelValuePairs();

--- a/browser-tests/unmarkedWinterStorage.ts
+++ b/browser-tests/unmarkedWinterStorage.ts
@@ -1,0 +1,77 @@
+import navbar from './selectors/navbar';
+import shared from './selectors/shared';
+import unmarkedWinterStorage from './selectors/unmarkedWinterStorage';
+import { isUnmarkedWinterStoragePage } from './utils/page';
+import { envUrl } from './utils/settings';
+import { applicantInformation, applicantOverview, wsBoatInformation } from './utils/sharedTests';
+
+const testData = {
+  address: 'Testiosoite 1',
+  boatLength: '4.4',
+  boatModel: 'Terhi 440',
+  boatName: 'Testivene',
+  boatRegistrationNumber: 'P12345',
+  boatType: 'Soutuvene',
+  boatTypeIndex: '2',
+  boatWidth: '1.75',
+  emailAddress: 'test@example.com',
+  firstName: 'Matti',
+  lastName: 'Meikäläinen',
+  municipality: 'Espoo',
+  phoneNumber: '+358 50 123 4567',
+  postalCode: '02100',
+  trailerRegistrationNumber: 'DEF-123',
+  winterStorageArea: 'Lähteelä',
+  winterStorageAreaIndex: 2,
+};
+
+fixture('Unmarked winter storage').page(envUrl());
+
+test('Unmarked winter storage notice, registered boat on trailer, private customer', async (t) => {
+  await t.click(navbar.unmarkedWinterStorage);
+  await isUnmarkedWinterStoragePage();
+
+  await areaSelection(t);
+  await wsBoatInformation(t, testData);
+
+  await t.expect(unmarkedWinterStorage.ownerInformationHeading.exists).ok();
+  await applicantInformation(t, testData, true);
+
+  const expectedBoatInfo = [
+    `Nimi: ${testData.boatName}`,
+    `Rekisterinumero: ${testData.boatRegistrationNumber}`,
+    `Tyyppi: ${testData.boatType}`,
+    `Malli: ${testData.boatModel}`,
+    `Leveys: ${testData.boatWidth}m`,
+    `Pituus: ${testData.boatLength}m`,
+    `Säilytystapa: Säilytän veneen trailerilla`,
+    `Trailerin rekisterinumero: ${testData.trailerRegistrationNumber}`,
+  ].join('\n');
+  await confirmation(t, expectedBoatInfo);
+});
+
+const areaSelection = async (t: TestController) => {
+  const { winterStorageAreaSelect, continueButton } = unmarkedWinterStorage.areaSelection;
+
+  await t
+    .click(winterStorageAreaSelect)
+    .click(winterStorageAreaSelect.find('option').withText(testData.winterStorageArea));
+
+  await t.wait(500).click(continueButton);
+};
+
+const confirmation = async (t: TestController, expectedBoatInfo: string) => {
+  const { textInOverview, getLabelValuePairs } = shared.overview;
+
+  await t.expect(unmarkedWinterStorage.confirmationHeading.exists).ok();
+
+  // Boat information
+  const labelValuePairs = await getLabelValuePairs();
+  await t.expect(labelValuePairs).eql(expectedBoatInfo);
+
+  // Chosen area
+  await t.expect(textInOverview(`${testData.winterStorageArea}`).exists).ok();
+
+  // Applicant
+  await applicantOverview(t, testData);
+};

--- a/browser-tests/unmarkedWinterStorage.ts
+++ b/browser-tests/unmarkedWinterStorage.ts
@@ -6,7 +6,11 @@ import {
 } from './selectors/unmarkedWinterStorage';
 import { isUnmarkedWinterStoragePage } from './utils/page';
 import { envUrl } from './utils/settings';
-import { applicantInformation, applicantOverview, wsBoatInformation } from './utils/sharedTests';
+import {
+  fillApplicantInformation,
+  fillApplicantOverview,
+  fillWsBoatInformation,
+} from './sharedTests/sharedTests';
 
 const testData = {
   address: 'Testiosoite 1',
@@ -34,11 +38,11 @@ test('Unmarked winter storage notice, registered boat on trailer, private custom
   await t.click(navbarSelectors.unmarkedWinterStorage);
   await isUnmarkedWinterStoragePage();
 
-  await areaSelection(t);
-  await wsBoatInformation(t, testData);
+  await selectArea(t);
+  await fillWsBoatInformation(t, testData);
 
   await t.expect(unmarkedWinterStorageSelectors.ownerInformationHeading.exists).ok();
-  await applicantInformation(t, testData, true);
+  await fillApplicantInformation(t, testData, true);
 
   const expectedBoatInfo = [
     `Nimi: ${testData.boatName}`,
@@ -50,10 +54,10 @@ test('Unmarked winter storage notice, registered boat on trailer, private custom
     `Säilytystapa: Säilytän veneen trailerilla`,
     `Trailerin rekisterinumero: ${testData.trailerRegistrationNumber}`,
   ].join('\n');
-  await confirmation(t, expectedBoatInfo);
+  await assertConfirmation(t, expectedBoatInfo);
 });
 
-const areaSelection = async (t: TestController) => {
+const selectArea = async (t: TestController) => {
   const { winterStorageAreaSelect, continueButton } = areaSelectionSelectors;
 
   await t
@@ -63,7 +67,7 @@ const areaSelection = async (t: TestController) => {
   await t.wait(500).click(continueButton);
 };
 
-const confirmation = async (t: TestController, expectedBoatInfo: string) => {
+const assertConfirmation = async (t: TestController, expectedBoatInfo: string) => {
   const { textInOverview, getLabelValuePairs } = overviewSelectors;
 
   await t.expect(unmarkedWinterStorageSelectors.confirmationHeading.exists).ok();
@@ -76,5 +80,5 @@ const confirmation = async (t: TestController, expectedBoatInfo: string) => {
   await t.expect(textInOverview(`${testData.winterStorageArea}`).exists).ok();
 
   // Applicant
-  await applicantOverview(t, testData);
+  await fillApplicantOverview(t, testData);
 };

--- a/browser-tests/unmarkedWinterStorage.ts
+++ b/browser-tests/unmarkedWinterStorage.ts
@@ -4,6 +4,11 @@ import {
   areaSelectionSelectors,
   unmarkedWinterStorageSelectors,
 } from './selectors/unmarkedWinterStorage';
+import {
+  ApplicantInformation,
+  UnmarkedWinterStorageChoice,
+  WsBoatInformation,
+} from './types/types';
 import { isUnmarkedWinterStoragePage } from './utils/page';
 import { envUrl } from './utils/settings';
 import {
@@ -12,7 +17,7 @@ import {
   fillWsBoatInformation,
 } from './sharedTests/sharedTests';
 
-const testData = {
+const testData: UnmarkedWinterStorageChoice & WsBoatInformation & ApplicantInformation = {
   address: 'Testiosoite 1',
   boatLength: '4.4',
   boatModel: 'Terhi 440',

--- a/browser-tests/utils/navigation.ts
+++ b/browser-tests/utils/navigation.ts
@@ -1,5 +1,5 @@
 import { t, ClientFunction } from 'testcafe';
-import { navbar } from '../selectors/navbar';
+import navbar from '../selectors/navbar';
 
 export const navigateToFrontPage = async () => {
   await t.click(navbar.mainLink);

--- a/browser-tests/utils/navigation.ts
+++ b/browser-tests/utils/navigation.ts
@@ -1,0 +1,15 @@
+import { t, ClientFunction } from 'testcafe';
+import { navbar } from '../selectors/navbar';
+
+export const navigateToFrontPage = async () => {
+  await t.click(navbar.mainLink);
+};
+
+export const navigateBack = ClientFunction(() => window.history.back());
+
+export const navigateForward = ClientFunction(() => window.history.forward());
+
+export const navigateBackAndForward = async () => {
+  await navigateBack();
+  await navigateForward();
+};

--- a/browser-tests/utils/navigation.ts
+++ b/browser-tests/utils/navigation.ts
@@ -1,8 +1,8 @@
 import { t, ClientFunction } from 'testcafe';
-import navbar from '../selectors/navbar';
+import { navbarSelectors } from '../selectors/navbar';
 
 export const navigateToFrontPage = async () => {
-  await t.click(navbar.mainLink);
+  await t.click(navbarSelectors.mainLink);
 };
 
 export const navigateBack = ClientFunction(() => window.history.back());

--- a/browser-tests/utils/page.ts
+++ b/browser-tests/utils/page.ts
@@ -1,0 +1,21 @@
+import { t } from 'testcafe';
+import { berth } from '../selectors/berth';
+import { frontPage } from '../selectors/frontPage';
+import { unmarkedWinterStorage } from '../selectors/unmarkedWinterStorage';
+import { winterStorage } from '../selectors/winterStorage';
+
+export const isFrontPage = async () => {
+  await t.expect(frontPage.title.innerText).eql('Venepaikat');
+};
+
+export const isBerthsPage = async () => {
+  await t.expect(berth.title.innerText).eql('Venepaikkahaku');
+};
+
+export const isWinterStoragePage = async () => {
+  await t.expect(winterStorage.title.innerText).eql('Talvisäilytyspaikat');
+};
+
+export const isUnmarkedWinterStoragePage = async () => {
+  await t.expect(unmarkedWinterStorage.title.innerText).eql('Nostojärjestysilmoitus');
+};

--- a/browser-tests/utils/page.ts
+++ b/browser-tests/utils/page.ts
@@ -1,8 +1,8 @@
 import { t } from 'testcafe';
-import { berth } from '../selectors/berth';
-import { frontPage } from '../selectors/frontPage';
-import { unmarkedWinterStorage } from '../selectors/unmarkedWinterStorage';
-import { winterStorage } from '../selectors/winterStorage';
+import berth from '../selectors/berth';
+import frontPage from '../selectors/frontPage';
+import unmarkedWinterStorage from '../selectors/unmarkedWinterStorage';
+import winterStorage from '../selectors/winterStorage';
 
 export const isFrontPage = async () => {
   await t.expect(frontPage.title.innerText).eql('Venepaikat');

--- a/browser-tests/utils/page.ts
+++ b/browser-tests/utils/page.ts
@@ -1,21 +1,21 @@
 import { t } from 'testcafe';
-import berth from '../selectors/berth';
-import frontPage from '../selectors/frontPage';
-import unmarkedWinterStorage from '../selectors/unmarkedWinterStorage';
-import winterStorage from '../selectors/winterStorage';
+import { berthSelectors } from '../selectors/berth';
+import { frontPageSelectors } from '../selectors/frontPage';
+import { unmarkedWinterStorageSelectors } from '../selectors/unmarkedWinterStorage';
+import { winterStorageSelectors } from '../selectors/winterStorage';
 
 export const isFrontPage = async () => {
-  await t.expect(frontPage.title.innerText).eql('Venepaikat');
+  await t.expect(frontPageSelectors.title.innerText).eql('Venepaikat');
 };
 
 export const isBerthsPage = async () => {
-  await t.expect(berth.title.innerText).eql('Venepaikkahaku');
+  await t.expect(berthSelectors.title.innerText).eql('Venepaikkahaku');
 };
 
 export const isWinterStoragePage = async () => {
-  await t.expect(winterStorage.title.innerText).eql('Talvisäilytyspaikat');
+  await t.expect(winterStorageSelectors.title.innerText).eql('Talvisäilytyspaikat');
 };
 
 export const isUnmarkedWinterStoragePage = async () => {
-  await t.expect(unmarkedWinterStorage.title.innerText).eql('Nostojärjestysilmoitus');
+  await t.expect(unmarkedWinterStorageSelectors.title.innerText).eql('Nostojärjestysilmoitus');
 };

--- a/browser-tests/utils/settings.ts
+++ b/browser-tests/utils/settings.ts
@@ -1,0 +1,17 @@
+// @ts-ignore
+// tslint:disable-next-line:no-var-requires
+require('dotenv').config({ path: '.env.development.local' });
+
+const TEST_ENV_URL = 'https://venepaikka.test.kuva.hel.ninja';
+const LOCAL_ENV_URL = 'http://localhost:3000';
+
+export const envUrl = (): string => {
+  switch (process.env.TEST_ENV) {
+    case 'local':
+      return LOCAL_ENV_URL;
+    case 'test':
+      return TEST_ENV_URL;
+    default:
+      return TEST_ENV_URL;
+  }
+};

--- a/browser-tests/utils/sharedTests.ts
+++ b/browser-tests/utils/sharedTests.ts
@@ -1,10 +1,15 @@
-import shared from '../selectors/shared';
+import {
+  applicantInformationSelectors,
+  boatInformationSelectors,
+  overviewSelectors,
+  yourSelectionSelectors,
+} from '../selectors/shared';
 
 export const yourSelection = async (
   t: TestController,
   testData: { choice2: string; choice1: string }
 ) => {
-  const { heading, getHarborHeading, getUpButtonForHeading, nextButton } = shared.yourSelection;
+  const { heading, getHarborHeading, getUpButtonForHeading, nextButton } = yourSelectionSelectors;
 
   await t.expect(heading.exists).ok();
 
@@ -43,7 +48,7 @@ export const wsBoatInformation = async (
     heading,
     nextButton,
     trailerRegistrationNumber,
-  } = shared.boatInformation;
+  } = boatInformationSelectors;
 
   await t.expect(heading.exists).ok();
 
@@ -90,7 +95,7 @@ export const applicantInformation = async (
     phoneNumber,
     emailAddress,
     nextButton,
-  } = shared.applicantInformation;
+  } = applicantInformationSelectors;
 
   if (!skipHeadingCheck) {
     await t.expect(heading.exists).ok();
@@ -124,7 +129,7 @@ export const overview = async (
   },
   expectedBoatInfo: string
 ) => {
-  const { heading, textInOverview, getLabelValuePairs } = shared.overview;
+  const { heading, textInOverview, getLabelValuePairs } = overviewSelectors;
 
   await t.expect(heading.exists).ok();
 
@@ -155,7 +160,7 @@ export const applicantOverview = (
     municipality: string;
   }
 ) => {
-  const { textInOverview } = shared.overview;
+  const { textInOverview } = overviewSelectors;
 
   return t
     .expect(textInOverview(testData.firstName).exists)

--- a/browser-tests/utils/sharedTests.ts
+++ b/browser-tests/utils/sharedTests.ts
@@ -1,14 +1,10 @@
-import {
-  applicantInformation as applicantInformationSelectors,
-  yourSelection as yourSelectionSelectors,
-  overview as overviewSelectors,
-} from '../selectors/shared';
+import shared from '../selectors/shared';
 
 export const yourSelection = async (
   t: TestController,
   testData: { choice2: string; choice1: string }
 ) => {
-  const { heading, getHarborHeading, getUpButtonForHeading, nextButton } = yourSelectionSelectors;
+  const { heading, getHarborHeading, getUpButtonForHeading, nextButton } = shared.yourSelection;
 
   await t.expect(heading.exists).ok();
 
@@ -23,6 +19,54 @@ export const yourSelection = async (
   await t.click(nextButton);
 };
 
+export const wsBoatInformation = async (
+  t: TestController,
+  testData: {
+    boatLength: string;
+    boatModel: string;
+    boatName: string;
+    boatRegistrationNumber: string;
+    boatType: string;
+    boatTypeIndex: string | undefined;
+    boatWidth: string;
+    trailerRegistrationNumber: string;
+  }
+) => {
+  const {
+    boatLength,
+    boatModel,
+    boatName,
+    boatRegistrationNumber,
+    boatStoredOnTrailer,
+    boatTypeSelect,
+    boatWidth,
+    heading,
+    nextButton,
+    trailerRegistrationNumber,
+  } = shared.boatInformation;
+
+  await t.expect(heading.exists).ok();
+
+  await t
+    .click(boatStoredOnTrailer)
+    .typeText(trailerRegistrationNumber, testData.trailerRegistrationNumber)
+    .typeText(boatRegistrationNumber, testData.boatRegistrationNumber)
+    .click(boatTypeSelect)
+    .click(boatTypeSelect.find('option').withText(testData.boatType))
+    .expect(boatTypeSelect.value)
+    .eql(testData.boatTypeIndex)
+    .click(boatWidth)
+    .pressKey('ctrl+a delete') // Clear width coming from first page of winter storage application
+    .typeText(boatWidth, testData.boatWidth)
+    .click(boatLength)
+    .pressKey('ctrl+a delete') // ditto for length
+    .typeText(boatLength, testData.boatLength)
+    .typeText(boatName, testData.boatName)
+    .typeText(boatModel, testData.boatModel);
+
+  await t.click(nextButton);
+};
+
 export const applicantInformation = async (
   t: TestController,
   testData: {
@@ -33,7 +77,8 @@ export const applicantInformation = async (
     municipality: string;
     phoneNumber: string;
     emailAddress: string;
-  }
+  },
+  skipHeadingCheck = false
 ) => {
   const {
     heading,
@@ -45,9 +90,11 @@ export const applicantInformation = async (
     phoneNumber,
     emailAddress,
     nextButton,
-  } = applicantInformationSelectors;
+  } = shared.applicantInformation;
 
-  await t.expect(heading.exists).ok();
+  if (!skipHeadingCheck) {
+    await t.expect(heading.exists).ok();
+  }
 
   await t
     .typeText(firstName, testData.firstName)
@@ -77,7 +124,7 @@ export const overview = async (
   },
   expectedBoatInfo: string
 ) => {
-  const { heading, textInOverview, getLabelValuePairs } = overviewSelectors;
+  const { heading, textInOverview, getLabelValuePairs } = shared.overview;
 
   await t.expect(heading.exists).ok();
 
@@ -85,7 +132,7 @@ export const overview = async (
   const labelValuePairs = await getLabelValuePairs();
   await t.expect(labelValuePairs).eql(expectedBoatInfo);
 
-  // Chosen harbors
+  // Chosen harbors/areas
   await t
     .expect(textInOverview(`1. ${testData.choice2}`).exists)
     .ok()
@@ -93,7 +140,24 @@ export const overview = async (
     .ok();
 
   // Applicant
-  await t
+  await applicantOverview(t, testData);
+};
+
+export const applicantOverview = (
+  t: TestController,
+  testData: {
+    firstName: string;
+    lastName: string;
+    emailAddress: string;
+    phoneNumber: string;
+    address: string;
+    postalCode: string;
+    municipality: string;
+  }
+) => {
+  const { textInOverview } = shared.overview;
+
+  return t
     .expect(textInOverview(testData.firstName).exists)
     .ok()
     .expect(textInOverview(testData.lastName).exists)

--- a/browser-tests/utils/sharedTests.ts
+++ b/browser-tests/utils/sharedTests.ts
@@ -1,0 +1,111 @@
+import {
+  applicantInformation as applicantInformationSelectors,
+  yourSelection as yourSelectionSelectors,
+  overview as overviewSelectors,
+} from '../selectors/shared';
+
+export const yourSelection = async (
+  t: TestController,
+  testData: { choice2: string; choice1: string }
+) => {
+  const { heading, getHarborHeading, getUpButtonForHeading, nextButton } = yourSelectionSelectors;
+
+  await t.expect(heading.exists).ok();
+
+  await t.click(getUpButtonForHeading(getHarborHeading(`2. ${testData.choice2}`))).wait(500);
+
+  await t
+    .expect(getHarborHeading(`1. ${testData.choice2}`).exists)
+    .ok()
+    .expect(getHarborHeading(`2. ${testData.choice1}`).exists)
+    .ok();
+
+  await t.click(nextButton);
+};
+
+export const applicantInformation = async (
+  t: TestController,
+  testData: {
+    firstName: string;
+    lastName: string;
+    address: string;
+    postalCode: string;
+    municipality: string;
+    phoneNumber: string;
+    emailAddress: string;
+  }
+) => {
+  const {
+    heading,
+    firstName,
+    lastName,
+    address,
+    postalCode,
+    municipalitySelect,
+    phoneNumber,
+    emailAddress,
+    nextButton,
+  } = applicantInformationSelectors;
+
+  await t.expect(heading.exists).ok();
+
+  await t
+    .typeText(firstName, testData.firstName)
+    .typeText(lastName, testData.lastName)
+    .typeText(address, testData.address)
+    .typeText(postalCode, testData.postalCode)
+    .click(municipalitySelect)
+    .click(municipalitySelect.find('option').withText(testData.municipality))
+    .typeText(phoneNumber, testData.phoneNumber)
+    .typeText(emailAddress, testData.emailAddress);
+
+  await t.click(nextButton);
+};
+
+export const overview = async (
+  t: TestController,
+  testData: {
+    address: string;
+    choice1: any;
+    choice2: any;
+    emailAddress: string;
+    firstName: string;
+    lastName: string;
+    municipality: string;
+    phoneNumber: string;
+    postalCode: string;
+  },
+  expectedBoatInfo: string
+) => {
+  const { heading, textInOverview, getLabelValuePairs } = overviewSelectors;
+
+  await t.expect(heading.exists).ok();
+
+  // Boat information
+  const labelValuePairs = await getLabelValuePairs();
+  await t.expect(labelValuePairs).eql(expectedBoatInfo);
+
+  // Chosen harbors
+  await t
+    .expect(textInOverview(`1. ${testData.choice2}`).exists)
+    .ok()
+    .expect(textInOverview(`2. ${testData.choice1}`).exists)
+    .ok();
+
+  // Applicant
+  await t
+    .expect(textInOverview(testData.firstName).exists)
+    .ok()
+    .expect(textInOverview(testData.lastName).exists)
+    .ok()
+    .expect(textInOverview(testData.emailAddress).exists)
+    .ok()
+    .expect(textInOverview(testData.phoneNumber).exists)
+    .ok()
+    .expect(textInOverview(testData.address).exists)
+    .ok()
+    .expect(textInOverview(testData.postalCode).exists)
+    .ok()
+    .expect(textInOverview(testData.municipality).exists)
+    .ok();
+};

--- a/browser-tests/utils/switchLanguage.ts
+++ b/browser-tests/utils/switchLanguage.ts
@@ -1,0 +1,34 @@
+import { navbar } from '../selectors/navbar';
+
+export const switchToFinnish = async (t: TestController) => {
+  await t
+    .click(navbar.languageSelect.button)
+    .expect(navbar.languageSelect.Finnish.visible)
+    .ok()
+
+    .click(navbar.languageSelect.Finnish)
+    .expect(navbar.languageSelect.button.innerText)
+    .eql('FI');
+};
+
+export const switchToSwedish = async (t: TestController) => {
+  await t
+    .click(navbar.languageSelect.button)
+    .expect(navbar.languageSelect.Swedish.visible)
+    .ok()
+
+    .click(navbar.languageSelect.Swedish)
+    .expect(navbar.languageSelect.button.innerText)
+    .eql('SV');
+};
+
+export const switchToEnglish = async (t: TestController) => {
+  await t
+    .click(navbar.languageSelect.button)
+    .expect(navbar.languageSelect.English.visible)
+    .ok()
+
+    .click(navbar.languageSelect.English)
+    .expect(navbar.languageSelect.button.innerText)
+    .eql('EN');
+};

--- a/browser-tests/utils/switchLanguage.ts
+++ b/browser-tests/utils/switchLanguage.ts
@@ -1,34 +1,36 @@
-import navbar from '../selectors/navbar';
+import { navbarSelectors } from '../selectors/navbar';
+
+const { languageSelect } = navbarSelectors;
 
 export const switchToFinnish = async (t: TestController) => {
   await t
-    .click(navbar.languageSelect.button)
-    .expect(navbar.languageSelect.Finnish.visible)
+    .click(languageSelect.button)
+    .expect(languageSelect.Finnish.visible)
     .ok()
 
-    .click(navbar.languageSelect.Finnish)
-    .expect(navbar.languageSelect.button.innerText)
+    .click(languageSelect.Finnish)
+    .expect(languageSelect.button.innerText)
     .eql('FI');
 };
 
 export const switchToSwedish = async (t: TestController) => {
   await t
-    .click(navbar.languageSelect.button)
-    .expect(navbar.languageSelect.Swedish.visible)
+    .click(languageSelect.button)
+    .expect(languageSelect.Swedish.visible)
     .ok()
 
-    .click(navbar.languageSelect.Swedish)
-    .expect(navbar.languageSelect.button.innerText)
+    .click(languageSelect.Swedish)
+    .expect(languageSelect.button.innerText)
     .eql('SV');
 };
 
 export const switchToEnglish = async (t: TestController) => {
   await t
-    .click(navbar.languageSelect.button)
-    .expect(navbar.languageSelect.English.visible)
+    .click(languageSelect.button)
+    .expect(languageSelect.English.visible)
     .ok()
 
-    .click(navbar.languageSelect.English)
-    .expect(navbar.languageSelect.button.innerText)
+    .click(languageSelect.English)
+    .expect(languageSelect.button.innerText)
     .eql('EN');
 };

--- a/browser-tests/utils/switchLanguage.ts
+++ b/browser-tests/utils/switchLanguage.ts
@@ -1,4 +1,4 @@
-import { navbar } from '../selectors/navbar';
+import navbar from '../selectors/navbar';
 
 export const switchToFinnish = async (t: TestController) => {
   await t

--- a/browser-tests/winterStorage.ts
+++ b/browser-tests/winterStorage.ts
@@ -2,11 +2,12 @@ import { navbar } from './selectors/navbar';
 import { winterStorage } from './selectors/winterStorage';
 import { isWinterStoragePage } from './utils/page';
 import { envUrl } from './utils/settings';
+import { applicantInformation, overview, yourSelection } from './utils/sharedTests';
 
 const testData = {
   address: 'Testiosoite 1',
-  area1: 'Laivalahti',
-  area2: 'Porslahti',
+  choice1: 'Laivalahti',
+  choice2: 'Porslahti',
   boatLength: '4.4',
   boatModel: 'Terhi 440',
   boatName: 'Testivene',
@@ -30,10 +31,21 @@ test('Winter storage application, registered boat on trailer, private customer',
   await isWinterStoragePage();
 
   await selectAreas(t);
-  await yourSelection(t);
+  await yourSelection(t, testData);
   await boatInformation(t);
-  await applicantInformation(t);
-  await overview(t);
+  await applicantInformation(t, testData);
+
+  const expectedBoatInfo = [
+    `Nimi: ${testData.boatName}`,
+    `Rekisterinumero: ${testData.boatRegistrationNumber}`,
+    `Tyyppi: ${testData.boatType}`,
+    `Malli: ${testData.boatModel}`,
+    `Leveys: ${testData.boatWidth}m`,
+    `Pituus: ${testData.boatLength}m`,
+    `Säilytystapa: Säilytän veneen trailerilla`,
+    `Trailerin rekisterinumero: ${testData.trailerRegistrationNumber}`,
+  ].join('\n');
+  await overview(t, testData, expectedBoatInfo);
 });
 
 const selectAreas = async (t: TestController) => {
@@ -55,29 +67,8 @@ const selectAreas = async (t: TestController) => {
 
   await t
     .click(harborListTab)
-    .click(getSelectButtonForArea(testData.area1))
-    .click(getSelectButtonForArea(testData.area2));
-
-  await t.click(nextButton);
-};
-
-const yourSelection = async (t: TestController) => {
-  const {
-    heading,
-    getHarborHeading,
-    getUpButtonForHeading,
-    nextButton,
-  } = winterStorage.yourSelection;
-
-  await t.expect(heading.exists).ok();
-
-  await t.click(getUpButtonForHeading(getHarborHeading(`2. ${testData.area2}`))).wait(500);
-
-  await t
-    .expect(getHarborHeading(`1. ${testData.area2}`).exists)
-    .ok()
-    .expect(getHarborHeading(`2. ${testData.area1}`).exists)
-    .ok();
+    .click(getSelectButtonForArea(testData.choice1))
+    .click(getSelectButtonForArea(testData.choice2));
 
   await t.click(nextButton);
 };
@@ -108,74 +99,4 @@ const boatInformation = async (t: TestController) => {
     .typeText(boatModel, testData.boatModel);
 
   await t.click(nextButton);
-};
-
-const applicantInformation = async (t: TestController) => {
-  const {
-    heading,
-    firstName,
-    lastName,
-    address,
-    postalCode,
-    municipalitySelect,
-    phoneNumber,
-    emailAddress,
-    nextButton,
-  } = winterStorage.applicantInformation;
-
-  await t.expect(heading.exists).ok();
-
-  await t
-    .typeText(firstName, testData.firstName)
-    .typeText(lastName, testData.lastName)
-    .typeText(address, testData.address)
-    .typeText(postalCode, testData.postalCode)
-    .click(municipalitySelect)
-    .click(municipalitySelect.find('option').withText(testData.municipality))
-    .typeText(phoneNumber, testData.phoneNumber)
-    .typeText(emailAddress, testData.emailAddress);
-
-  await t.click(nextButton);
-};
-
-const overview = async (t: TestController) => {
-  const { heading, textInOverview, getLabelValuePairs } = winterStorage.overview;
-
-  await t.expect(heading.exists).ok();
-
-  // Boat information
-  const labelValuePairs = await getLabelValuePairs();
-  const expectedContent = [
-    `Nimi: ${testData.boatName}`,
-    `Rekisterinumero: ${testData.boatRegistrationNumber}`,
-    `Tyyppi: ${testData.boatType}`,
-    `Malli: ${testData.boatModel}`,
-    `Leveys: ${testData.boatWidth}m`,
-    `Pituus: ${testData.boatLength}m`,
-  ].join('\n');
-  await t.expect(labelValuePairs).eql(expectedContent);
-
-  // Chosen harbors
-  await t
-    .expect(textInOverview(`1. ${testData.area2}`).exists)
-    .ok()
-    .expect(textInOverview(`2. ${testData.area1}`).exists)
-    .ok();
-
-  // Applicant
-  await t
-    .expect(textInOverview(testData.firstName).exists)
-    .ok()
-    .expect(textInOverview(testData.lastName).exists)
-    .ok()
-    .expect(textInOverview(testData.emailAddress).exists)
-    .ok()
-    .expect(textInOverview(testData.phoneNumber).exists)
-    .ok()
-    .expect(textInOverview(testData.address).exists)
-    .ok()
-    .expect(textInOverview(testData.postalCode).exists)
-    .ok()
-    .expect(textInOverview(testData.municipality).exists)
-    .ok();
 };

--- a/browser-tests/winterStorage.ts
+++ b/browser-tests/winterStorage.ts
@@ -1,5 +1,5 @@
-import navbar from './selectors/navbar';
-import winterStorage from './selectors/winterStorage';
+import { navbarSelectors } from './selectors/navbar';
+import { selectAreasSelectors } from './selectors/winterStorage';
 import { isWinterStoragePage } from './utils/page';
 import { envUrl } from './utils/settings';
 import {
@@ -32,7 +32,7 @@ const testData = {
 fixture('Winter storage').page(envUrl());
 
 test('Winter storage application, registered boat on trailer, private customer', async (t) => {
-  await t.click(navbar.winterStorage);
+  await t.click(navbarSelectors.winterStorage);
   await isWinterStoragePage();
 
   await selectAreas(t);
@@ -62,7 +62,7 @@ const selectAreas = async (t: TestController) => {
     harborListTab,
     nextButton,
     getSelectButtonForArea,
-  } = winterStorage.selectAreas;
+  } = selectAreasSelectors;
 
   await t
     .typeText(boatWidth, testData.boatWidth)

--- a/browser-tests/winterStorage.ts
+++ b/browser-tests/winterStorage.ts
@@ -1,0 +1,181 @@
+import { navbar } from './selectors/navbar';
+import { winterStorage } from './selectors/winterStorage';
+import { isWinterStoragePage } from './utils/page';
+import { envUrl } from './utils/settings';
+
+const testData = {
+  address: 'Testiosoite 1',
+  area1: 'Laivalahti',
+  area2: 'Porslahti',
+  boatLength: '4.4',
+  boatModel: 'Terhi 440',
+  boatName: 'Testivene',
+  boatRegistrationNumber: 'P12345',
+  boatType: 'Soutuvene',
+  boatTypeIndex: '2',
+  boatWidth: '1.75',
+  emailAddress: 'test@example.com',
+  firstName: 'Matti',
+  lastName: 'Meikäläinen',
+  municipality: 'Espoo',
+  phoneNumber: '+358 50 123 4567',
+  postalCode: '02100',
+  trailerRegistrationNumber: 'DEF-123',
+};
+
+fixture('Winter storage').page(envUrl());
+
+test('Winter storage application, registered boat on trailer, private customer', async (t) => {
+  await t.click(navbar.winterStorage);
+  await isWinterStoragePage();
+
+  await selectAreas(t);
+  await yourSelection(t);
+  await boatInformation(t);
+  await applicantInformation(t);
+  await overview(t);
+});
+
+const selectAreas = async (t: TestController) => {
+  const {
+    boatWidth,
+    boatLength,
+    boatStoredOnTrailer,
+    electricity,
+    harborListTab,
+    nextButton,
+    getSelectButtonForArea,
+  } = winterStorage.selectAreas;
+
+  await t
+    .typeText(boatWidth, testData.boatWidth)
+    .typeText(boatLength, testData.boatLength)
+    .click(boatStoredOnTrailer)
+    .click(electricity);
+
+  await t
+    .click(harborListTab)
+    .click(getSelectButtonForArea(testData.area1))
+    .click(getSelectButtonForArea(testData.area2));
+
+  await t.click(nextButton);
+};
+
+const yourSelection = async (t: TestController) => {
+  const {
+    heading,
+    getHarborHeading,
+    getUpButtonForHeading,
+    nextButton,
+  } = winterStorage.yourSelection;
+
+  await t.expect(heading.exists).ok();
+
+  await t.click(getUpButtonForHeading(getHarborHeading(`2. ${testData.area2}`))).wait(500);
+
+  await t
+    .expect(getHarborHeading(`1. ${testData.area2}`).exists)
+    .ok()
+    .expect(getHarborHeading(`2. ${testData.area1}`).exists)
+    .ok();
+
+  await t.click(nextButton);
+};
+
+const boatInformation = async (t: TestController) => {
+  const {
+    boatModel,
+    boatName,
+    boatRegistrationNumber,
+    boatStoredOnTrailer,
+    boatTypeSelect,
+    heading,
+    nextButton,
+    trailerRegistrationNumber,
+  } = winterStorage.boatInformation;
+
+  await t.expect(heading.exists).ok();
+
+  await t
+    .click(boatStoredOnTrailer)
+    .typeText(trailerRegistrationNumber, testData.trailerRegistrationNumber)
+    .typeText(boatRegistrationNumber, testData.boatRegistrationNumber)
+    .click(boatTypeSelect)
+    .click(boatTypeSelect.find('option').withText(testData.boatType))
+    .expect(boatTypeSelect.value)
+    .eql(testData.boatTypeIndex)
+    .typeText(boatName, testData.boatName)
+    .typeText(boatModel, testData.boatModel);
+
+  await t.click(nextButton);
+};
+
+const applicantInformation = async (t: TestController) => {
+  const {
+    heading,
+    firstName,
+    lastName,
+    address,
+    postalCode,
+    municipalitySelect,
+    phoneNumber,
+    emailAddress,
+    nextButton,
+  } = winterStorage.applicantInformation;
+
+  await t.expect(heading.exists).ok();
+
+  await t
+    .typeText(firstName, testData.firstName)
+    .typeText(lastName, testData.lastName)
+    .typeText(address, testData.address)
+    .typeText(postalCode, testData.postalCode)
+    .click(municipalitySelect)
+    .click(municipalitySelect.find('option').withText(testData.municipality))
+    .typeText(phoneNumber, testData.phoneNumber)
+    .typeText(emailAddress, testData.emailAddress);
+
+  await t.click(nextButton);
+};
+
+const overview = async (t: TestController) => {
+  const { heading, textInOverview, getLabelValuePairs } = winterStorage.overview;
+
+  await t.expect(heading.exists).ok();
+
+  // Boat information
+  const labelValuePairs = await getLabelValuePairs();
+  const expectedContent = [
+    `Nimi: ${testData.boatName}`,
+    `Rekisterinumero: ${testData.boatRegistrationNumber}`,
+    `Tyyppi: ${testData.boatType}`,
+    `Malli: ${testData.boatModel}`,
+    `Leveys: ${testData.boatWidth}m`,
+    `Pituus: ${testData.boatLength}m`,
+  ].join('\n');
+  await t.expect(labelValuePairs).eql(expectedContent);
+
+  // Chosen harbors
+  await t
+    .expect(textInOverview(`1. ${testData.area2}`).exists)
+    .ok()
+    .expect(textInOverview(`2. ${testData.area1}`).exists)
+    .ok();
+
+  // Applicant
+  await t
+    .expect(textInOverview(testData.firstName).exists)
+    .ok()
+    .expect(textInOverview(testData.lastName).exists)
+    .ok()
+    .expect(textInOverview(testData.emailAddress).exists)
+    .ok()
+    .expect(textInOverview(testData.phoneNumber).exists)
+    .ok()
+    .expect(textInOverview(testData.address).exists)
+    .ok()
+    .expect(textInOverview(testData.postalCode).exists)
+    .ok()
+    .expect(textInOverview(testData.municipality).exists)
+    .ok();
+};

--- a/browser-tests/winterStorage.ts
+++ b/browser-tests/winterStorage.ts
@@ -1,8 +1,13 @@
-import { navbar } from './selectors/navbar';
-import { winterStorage } from './selectors/winterStorage';
+import navbar from './selectors/navbar';
+import winterStorage from './selectors/winterStorage';
 import { isWinterStoragePage } from './utils/page';
 import { envUrl } from './utils/settings';
-import { applicantInformation, overview, yourSelection } from './utils/sharedTests';
+import {
+  applicantInformation,
+  overview,
+  wsBoatInformation,
+  yourSelection,
+} from './utils/sharedTests';
 
 const testData = {
   address: 'Testiosoite 1',
@@ -32,7 +37,7 @@ test('Winter storage application, registered boat on trailer, private customer',
 
   await selectAreas(t);
   await yourSelection(t, testData);
-  await boatInformation(t);
+  await wsBoatInformation(t, testData);
   await applicantInformation(t, testData);
 
   const expectedBoatInfo = [
@@ -69,34 +74,6 @@ const selectAreas = async (t: TestController) => {
     .click(harborListTab)
     .click(getSelectButtonForArea(testData.choice1))
     .click(getSelectButtonForArea(testData.choice2));
-
-  await t.click(nextButton);
-};
-
-const boatInformation = async (t: TestController) => {
-  const {
-    boatModel,
-    boatName,
-    boatRegistrationNumber,
-    boatStoredOnTrailer,
-    boatTypeSelect,
-    heading,
-    nextButton,
-    trailerRegistrationNumber,
-  } = winterStorage.boatInformation;
-
-  await t.expect(heading.exists).ok();
-
-  await t
-    .click(boatStoredOnTrailer)
-    .typeText(trailerRegistrationNumber, testData.trailerRegistrationNumber)
-    .typeText(boatRegistrationNumber, testData.boatRegistrationNumber)
-    .click(boatTypeSelect)
-    .click(boatTypeSelect.find('option').withText(testData.boatType))
-    .expect(boatTypeSelect.value)
-    .eql(testData.boatTypeIndex)
-    .typeText(boatName, testData.boatName)
-    .typeText(boatModel, testData.boatModel);
 
   await t.click(nextButton);
 };

--- a/browser-tests/winterStorage.ts
+++ b/browser-tests/winterStorage.ts
@@ -1,5 +1,6 @@
 import { navbarSelectors } from './selectors/navbar';
 import { selectAreasSelectors } from './selectors/winterStorage';
+import { ApplicantInformation, Choices, WsBoatInformation } from './types/types';
 import { isWinterStoragePage } from './utils/page';
 import { envUrl } from './utils/settings';
 import {
@@ -9,7 +10,7 @@ import {
   swapSelections,
 } from './sharedTests/sharedTests';
 
-const testData = {
+const testData: Choices & WsBoatInformation & ApplicantInformation = {
   address: 'Testiosoite 1',
   choice1: 'Laivalahti',
   choice2: 'Porslahti',

--- a/browser-tests/winterStorage.ts
+++ b/browser-tests/winterStorage.ts
@@ -3,11 +3,11 @@ import { selectAreasSelectors } from './selectors/winterStorage';
 import { isWinterStoragePage } from './utils/page';
 import { envUrl } from './utils/settings';
 import {
-  applicantInformation,
-  overview,
-  wsBoatInformation,
-  yourSelection,
-} from './utils/sharedTests';
+  fillApplicantInformation,
+  assertOverview,
+  fillWsBoatInformation,
+  swapSelections,
+} from './sharedTests/sharedTests';
 
 const testData = {
   address: 'Testiosoite 1',
@@ -36,9 +36,9 @@ test('Winter storage application, registered boat on trailer, private customer',
   await isWinterStoragePage();
 
   await selectAreas(t);
-  await yourSelection(t, testData);
-  await wsBoatInformation(t, testData);
-  await applicantInformation(t, testData);
+  await swapSelections(t, testData);
+  await fillWsBoatInformation(t, testData);
+  await fillApplicantInformation(t, testData);
 
   const expectedBoatInfo = [
     `Nimi: ${testData.boatName}`,
@@ -50,7 +50,7 @@ test('Winter storage application, registered boat on trailer, private customer',
     `Säilytystapa: Säilytän veneen trailerilla`,
     `Trailerin rekisterinumero: ${testData.trailerRegistrationNumber}`,
   ].join('\n');
-  await overview(t, testData, expectedBoatInfo);
+  await assertOverview(t, testData, expectedBoatInfo);
 });
 
 const selectAreas = async (t: TestController) => {

--- a/package.json
+++ b/package.json
@@ -63,21 +63,21 @@
     "typescript": "^3.9.5"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "browser-test": "testcafe \"chrome --window-size='1920,1080'\" browser-tests/",
+    "browser-test:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1920,1080'\" browser-tests/ -s takeOnFails=true",
+    "browser-test:local": "TEST_ENV=local testcafe \"chrome --window-size='1920,1080'\" browser-tests/",
     "build": "react-scripts build",
     "eject": "react-scripts eject",
-    "prettier": "prettier",
     "lint": "tslint 'src/**/*.ts?(x)'",
     "lint:fix": "tslint 'src/**/*.ts?(x)' --fix",
-    "test:ci": "CI=true && yarn test:coverage",
-    "test": "react-scripts test --no-watch",
-    "test:watch": "react-scripts test",
-    "test:coverage": "react-scripts test --coverage",
-    "types:generate": "apollo client:codegen --target=typescript --globalTypesFile='src/__generated__/globalTypes.ts'",
     "pre-push": "yarn types:generate && yarn lint",
-    "browser-test": "testcafe \"chrome --window-size='1920,1080'\" browser-tests/",
-    "browser-test:local": "TEST_ENV=local testcafe \"chrome --window-size='1920,1080'\" browser-tests/",
-    "browser-test:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1920,1080'\" browser-tests/ -s takeOnFails=true"
+    "prettier": "prettier",
+    "start": "react-scripts start",
+    "test": "react-scripts test --no-watch",
+    "test:ci": "CI=true && yarn test:coverage",
+    "test:coverage": "react-scripts test --coverage",
+    "test:watch": "react-scripts test",
+    "types:generate": "apollo client:codegen --target=typescript --globalTypesFile='src/__generated__/globalTypes.ts'"
   },
   "devDependencies": {
     "@testing-library/testcafe": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "node-sass": "^4.14.1",
     "open-city-design": "^1.0.0-alpha.3",
     "piwik-react-router": "^0.12.1",
+    "query-string": "6.13.1",
     "react": "^16.13.1",
     "react-apollo": "^3.1.5",
     "react-app-polyfill": "^1.0.6",
@@ -59,8 +60,7 @@
     "redux-persist": "^5.10.0",
     "redux-promise-middleware": "^5.1.1",
     "redux-thunk": "^2.3.0",
-    "typescript": "^3.9.5",
-    "query-string": "6.13.1"
+    "typescript": "^3.9.5"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -74,9 +74,13 @@
     "test:watch": "react-scripts test",
     "test:coverage": "react-scripts test --coverage",
     "types:generate": "apollo client:codegen --target=typescript --globalTypesFile='src/__generated__/globalTypes.ts'",
-    "pre-push": "yarn types:generate && yarn lint"
+    "pre-push": "yarn types:generate && yarn lint",
+    "browser-test": "testcafe \"chrome --window-size='1920,1080'\" browser-tests/",
+    "browser-test:local": "TEST_ENV=local testcafe \"chrome --window-size='1920,1080'\" browser-tests/",
+    "browser-test:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1920,1080'\" browser-tests/ -s takeOnFails=true"
   },
   "devDependencies": {
+    "@testing-library/testcafe": "^4.2.3",
     "apollo": "^2.28.3",
     "codecov": "^3.7.0",
     "dotenv": "^8.2.0",
@@ -84,6 +88,7 @@
     "husky": "^4.2.5",
     "lint-staged": "^10.2.9",
     "prettier": "^2.0.5",
+    "testcafe": "^1.9.4",
     "tslint": "^6.1.2",
     "tslint-config-airbnb": "^5.11.2",
     "tslint-config-prettier": "^1.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,6 +110,13 @@
   dependencies:
     "@babel/highlight" "^7.10.1"
 
+"@babel/code-frame@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
+  integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/compat-data@^7.10.1", "@babel/compat-data@^7.9.0":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.10.1.tgz#b1085ffe72cd17bf2c0ee790fc09f9626011b2db"
@@ -398,6 +405,15 @@
   integrity sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.1"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
+  integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -1162,6 +1178,14 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-transform-typescript" "^7.9.0"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz#ffee91da0eb4c6dae080774e94ba606368e414f4"
+  integrity sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime-corejs3@^7.8.3":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.10.2.tgz#3511797ddf9a3d6f3ce46b99cc835184817eaa4e"
@@ -1188,6 +1212,13 @@
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.4.tgz#a6724f1a6b8d2f6ea5236dbfe58c7d7ea9c5eb99"
   integrity sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1478,6 +1509,17 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
+
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -1856,10 +1898,36 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
+"@testing-library/dom@^7.2.2":
+  version "7.26.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.26.5.tgz#804a74fc893bf6da1a7970dbca7b94c2bbfe983d"
+  integrity sha512-2v/fv0s4keQjJIcD4bjfJMFtvxz5icartxUWdIZVNJR539WD9oxVrvIAPw+3Ydg4RLgxt0rvQx3L9cAjCci0Kg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.10.3"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.1"
+    lz-string "^1.4.4"
+    pretty-format "^26.4.2"
+
+"@testing-library/testcafe@^4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/testcafe/-/testcafe-4.2.3.tgz#a46b8aea2b5eb8cbebaca5f8461a6f70296143b1"
+  integrity sha512-g1qRX5KQ2+TG/p63kRaoAZ9LTGqt8Qv1dJbOmySjax8Ik2ml1tU4hxu8PVay05LTLJgR59F0pX3sfIOHg5Hi6g==
+  dependencies:
+    "@testing-library/dom" "^7.2.2"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
+  integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
 "@types/babel__core@^7.1.0":
   version "7.1.8"
@@ -1926,10 +1994,20 @@
     "@types/cheerio" "*"
     "@types/react" "*"
 
+"@types/error-stack-parser@^1.3.18":
+  version "1.3.18"
+  resolved "https://registry.yarnpkg.com/@types/error-stack-parser/-/error-stack-parser-1.3.18.tgz#e01c9f8c85ca83b610320c62258b0c9026ade0f7"
+  integrity sha1-4ByfjIXKg7YQMgxiJYsMkCat4Pc=
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
+"@types/estree@^0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
 "@types/geojson@*":
   version "7946.0.7"
@@ -1977,6 +2055,13 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
+  integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
+  dependencies:
+    "@types/istanbul-lib-report" "*"
+
 "@types/jest@^26.0.0":
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.0.tgz#a6d7573dffa9c68cbbdf38f2e0de26f159e11134"
@@ -2001,6 +2086,11 @@
   version "4.14.155"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.155.tgz#e2b4514f46a261fd11542e47519c20ebce7bc23a"
   integrity sha512-vEcX7S7aPhsBCivxMwAANQburHBtfN9RdyXFk84IJmu2Z4Hkg1tOFgaslRiEqqvoLtbCBi6ika1EMspE+NZ9Lg==
+
+"@types/lodash@^4.14.72":
+  version "4.14.164"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.164.tgz#52348bcf909ac7b4c1bcbeda5c23135176e5dfa0"
+  integrity sha512-fXCEmONnrtbYUc5014avwBeMdhHHO8YJCkOBflUL9EoJBSKZ1dei+VO74fA7JkTHZ1GvZack2TyIw5U+1lT8jg==
 
 "@types/minimatch@*":
   version "3.0.3"
@@ -2031,6 +2121,11 @@
   version "14.0.13"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.13.tgz#ee1128e881b874c371374c1f72201893616417c9"
   integrity sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==
+
+"@types/node@^10.12.19":
+  version "10.17.44"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.44.tgz#3945e6b702cb6403f22b779c8ea9e5c3f44ead40"
+  integrity sha512-vHPAyBX1ffLcy4fQHmDyIUMUb42gHZjPHU66nhvbMzAWJqHnySGZ6STwN3rwrnSd1FHB0DI/RWgGELgKSYRDmw==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -2408,6 +2503,13 @@ acorn-globals@^4.1.0, acorn-globals@^4.3.0:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
+acorn-hammerhead@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/acorn-hammerhead/-/acorn-hammerhead-0.3.0.tgz#2f83730f15e8450169c3dfd88af3ea9405ea973d"
+  integrity sha512-Izrr9mXONhWc7q8fqUe6ijQy+KjmyQlgdWARgaCVjds+nPpoSS298FY8uSVN/to8nKVTtkJpafNUlACWxwZS5w==
+  dependencies:
+    "@types/estree" "^0.0.39"
+
 acorn-jsx@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
@@ -2529,6 +2631,11 @@ ansi-colors@^3.0.0, ansi-colors@^3.2.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
+
+ansi-escapes@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
+  integrity sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=
 
 ansi-escapes@^3.0.0, ansi-escapes@^3.1.0:
   version "3.2.0"
@@ -2931,6 +3038,14 @@ aria-query@^3.0.0:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
 
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
+
 arity-n@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/arity-n/-/arity-n-1.0.4.tgz#d9e76b11733e08569c0847ae7b39b2860b30b745"
@@ -2966,6 +3081,11 @@ array-find-index@^1.0.1:
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
   integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
 
+array-find@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-find/-/array-find-1.0.0.tgz#6c8e286d11ed768327f8e62ecee87353ca3e78b8"
+  integrity sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -2985,7 +3105,7 @@ array-includes@^3.0.3, array-includes@^3.1.1:
     es-abstract "^1.17.0"
     is-string "^1.0.5"
 
-array-union@^1.0.1:
+array-union@^1.0.1, array-union@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
   integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
@@ -3033,6 +3153,21 @@ asap@~2.0.3, asap@~2.0.6:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
+asar@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/asar/-/asar-2.1.0.tgz#97c6a570408c4e38a18d4a3fb748a621b5a7844e"
+  integrity sha512-d2Ovma+bfqNpvBzY/KU8oPY67ZworixTpkjSx0PCXnQi67c2cXmssaTxpFDUM0ttopXoGx/KRxNg/GDThYbXQA==
+  dependencies:
+    chromium-pickle-js "^0.2.0"
+    commander "^2.20.0"
+    cuint "^0.2.2"
+    glob "^7.1.3"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    tmp-promise "^1.0.5"
+  optionalDependencies:
+    "@types/glob" "^7.1.1"
+
 asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
@@ -3069,6 +3204,11 @@ assert@^1.1.1:
     object-assign "^4.1.1"
     util "0.10.3"
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -3099,6 +3239,11 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
+async-exit-hook@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/async-exit-hook/-/async-exit-hook-1.1.2.tgz#8095d75e488c29acee0551fe87252169d789cfba"
+  integrity sha1-gJXXXkiMKazuBVH+hyUhadeJz7o=
+
 async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
@@ -3108,6 +3253,11 @@ async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
+async@0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.2.6.tgz#ad3f373d9249ae324881565582bc90e152abbd68"
+  integrity sha1-rT83PZJJrjJIgVZVgryQ4VKrvWg=
 
 async@^2.6.2:
   version "2.6.3"
@@ -3164,7 +3314,7 @@ axobject-query@^2.0.2:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.1.2.tgz#2bdffc0371e643e5f03ba99065d5179b9ca79799"
   integrity sha512-ICt34ZmrVt8UQnvPl6TVyDTkmhXmAyAT4Jh5ugfGUX4MOrZ+U/ZY6/sdylRw3qGNr9Ub5AJsaHeDMzNLehRdOQ==
 
-babel-code-frame@^6.22.0:
+babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
@@ -3172,6 +3322,31 @@ babel-code-frame@^6.22.0:
     chalk "^1.1.3"
     esutils "^2.0.2"
     js-tokens "^3.0.2"
+
+babel-core@^6.22.1, babel-core@^6.26.0:
+  version "6.26.3"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
+  integrity sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.1"
+    debug "^2.6.9"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.8"
+    slash "^1.0.0"
+    source-map "^0.5.7"
 
 babel-eslint@10.1.0:
   version "10.1.0"
@@ -3191,6 +3366,161 @@ babel-extract-comments@^1.0.0:
   integrity sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==
   dependencies:
     babylon "^6.18.0"
+
+babel-generator@^6.26.0:
+  version "6.26.1"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
+  integrity sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==
+  dependencies:
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    detect-indent "^4.0.0"
+    jsesc "^1.3.0"
+    lodash "^4.17.4"
+    source-map "^0.5.7"
+    trim-right "^1.0.1"
+
+babel-helper-bindify-decorators@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz#14c19e5f142d7b47f19a52431e52b1ccbc40a330"
+  integrity sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664"
+  integrity sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=
+  dependencies:
+    babel-helper-explode-assignable-expression "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-builder-react-jsx@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz#39ff8313b75c8b65dceff1f31d383e0ff2a408a0"
+  integrity sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    esutils "^2.0.2"
+
+babel-helper-call-delegate@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz#ece6aacddc76e41c3461f88bfc575bd0daa2df8d"
+  integrity sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=
+  dependencies:
+    babel-helper-hoist-variables "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-define-map@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz#a5f56dab41a25f97ecb498c7ebaca9819f95be5f"
+  integrity sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
+
+babel-helper-explode-assignable-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa"
+  integrity sha1-8luCz33BBDPFX3BZLVdGQArCLKo=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-explode-class@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz#7dc2a3910dee007056e1e31d640ced3d54eaa9eb"
+  integrity sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=
+  dependencies:
+    babel-helper-bindify-decorators "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-function-name@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz#d3475b8c03ed98242a25b48351ab18399d3580a9"
+  integrity sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=
+  dependencies:
+    babel-helper-get-function-arity "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-get-function-arity@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz#8f7782aa93407c41d3aa50908f89b031b1b6853d"
+  integrity sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-hoist-variables@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz#1ecb27689c9d25513eadbc9914a73f5408be7a76"
+  integrity sha1-HssnaJydJVE+rbyZFKc/VAi+enY=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-optimise-call-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz#f7a13427ba9f73f8f4fa993c54a97882d1244257"
+  integrity sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-regex@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz#325c59f902f82f24b74faceed0363954f6495e72"
+  integrity sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
+
+babel-helper-remap-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b"
+  integrity sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-replace-supers@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz#bf6dbfe43938d17369a213ca8a8bf74b6a90ab1a"
+  integrity sha1-v22/5Dk40XNpohPKiov3S2qQqxo=
+  dependencies:
+    babel-helper-optimise-call-expression "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helpers@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helpers/-/babel-helpers-6.24.1.tgz#3471de9caec388e5c850e597e58a26ddf37602b2"
+  integrity sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
 
 babel-jest@^24.9.0:
   version "24.9.0"
@@ -3215,6 +3545,20 @@ babel-loader@8.1.0:
     mkdirp "^0.5.3"
     pify "^4.0.1"
     schema-utils "^2.6.5"
+
+babel-messages@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
+  integrity sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-check-es2015-constants@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
+  integrity sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=
+  dependencies:
+    babel-runtime "^6.22.0"
 
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
@@ -3254,12 +3598,308 @@ babel-plugin-named-asset-import@^0.3.6:
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.6.tgz#c9750a1b38d85112c9e166bf3ef7c5dbc605f4be"
   integrity sha512-1aGDUfL1qOOIoqk9QKGIo2lANk+C7ko/fqH0uIyC71x3PEGz0uVP8ISgfEsFuG+FKmjHTvFK/nNM8dowpmUxLA==
 
+babel-plugin-syntax-async-functions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+  integrity sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=
+
+babel-plugin-syntax-async-generators@^6.5.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz#6bc963ebb16eccbae6b92b596eb7f35c342a8b9a"
+  integrity sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=
+
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+  integrity sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=
+
+babel-plugin-syntax-decorators@^6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
+  integrity sha1-MSVjtNvePMgGzuPkFszurd0RrAs=
+
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
+  integrity sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=
+
+babel-plugin-syntax-exponentiation-operator@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
+  integrity sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=
+
+babel-plugin-syntax-flow@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
+  integrity sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=
+
+babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
+
 babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
   integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
 
-babel-plugin-transform-object-rest-spread@^6.26.0:
+babel-plugin-syntax-trailing-function-commas@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
+  integrity sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=
+
+babel-plugin-transform-async-generator-functions@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz#f058900145fd3e9907a6ddf28da59f215258a5db"
+  integrity sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-generators "^6.5.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-async-to-generator@^6.22.0, babel-plugin-transform-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
+  integrity sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-functions "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-properties@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  integrity sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-decorators@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz#788013d8f8c6b5222bdf7b344390dfd77569e24d"
+  integrity sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=
+  dependencies:
+    babel-helper-explode-class "^6.24.1"
+    babel-plugin-syntax-decorators "^6.13.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-arrow-functions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
+  integrity sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz#bbc51b49f964d70cb8d8e0b94e820246ce3a6141"
+  integrity sha1-u8UbSflk1wy42OC5ToICRs46YUE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-block-scoping@^6.23.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
+  integrity sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
+
+babel-plugin-transform-es2015-classes@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
+  integrity sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=
+  dependencies:
+    babel-helper-define-map "^6.24.1"
+    babel-helper-function-name "^6.24.1"
+    babel-helper-optimise-call-expression "^6.24.1"
+    babel-helper-replace-supers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-computed-properties@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz#6fe2a8d16895d5634f4cd999b6d3480a308159b3"
+  integrity sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-destructuring@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
+  integrity sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-duplicate-keys@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz#73eb3d310ca969e3ef9ec91c53741a6f1576423e"
+  integrity sha1-c+s9MQypaePvnskcU3QabxV2Qj4=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-for-of@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz#f47c95b2b613df1d3ecc2fdb7573623c75248691"
+  integrity sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-function-name@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz#834c89853bc36b1af0f3a4c5dbaa94fd8eacaa8b"
+  integrity sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-literals@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz#4f54a02d6cd66cf915280019a31d31925377ca2e"
+  integrity sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015-modules-amd@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz#3b3e54017239842d6d19c3011c4bd2f00a00d154"
+  integrity sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=
+  dependencies:
+    babel-plugin-transform-es2015-modules-commonjs "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
+  version "6.26.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"
+  integrity sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==
+  dependencies:
+    babel-plugin-transform-strict-mode "^6.24.1"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-types "^6.26.0"
+
+babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz#ff89a142b9119a906195f5f106ecf305d9407d23"
+  integrity sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=
+  dependencies:
+    babel-helper-hoist-variables "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-modules-umd@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz#ac997e6285cd18ed6176adb607d602344ad38468"
+  integrity sha1-rJl+YoXNGO1hdq22B9YCNErThGg=
+  dependencies:
+    babel-plugin-transform-es2015-modules-amd "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-object-super@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz#24cef69ae21cb83a7f8603dad021f572eb278f8d"
+  integrity sha1-JM72muIcuDp/hgPa0CH1cusnj40=
+  dependencies:
+    babel-helper-replace-supers "^6.24.1"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-parameters@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz#57ac351ab49caf14a97cd13b09f66fdf0a625f2b"
+  integrity sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=
+  dependencies:
+    babel-helper-call-delegate "^6.24.1"
+    babel-helper-get-function-arity "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-shorthand-properties@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz#24f875d6721c87661bbd99a4622e51f14de38aa0"
+  integrity sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-spread@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz#d6d68a99f89aedc4536c81a542e8dd9f1746f8d1"
+  integrity sha1-1taKmfia7cRTbIGlQujdnxdG+NE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-sticky-regex@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz#00c1cdb1aca71112cdf0cf6126c2ed6b457ccdbc"
+  integrity sha1-AMHNsaynERLN8M9hJsLta0V8zbw=
+  dependencies:
+    babel-helper-regex "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-template-literals@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz#a84b3450f7e9f8f1f6839d6d687da84bb1236d8d"
+  integrity sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372"
+  integrity sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-unicode-regex@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz#d38b12f42ea7323f729387f18a7c5ae1faeb35e9"
+  integrity sha1-04sS9C6nMj9yk4fxinxa4frrNek=
+  dependencies:
+    babel-helper-regex "^6.24.1"
+    babel-runtime "^6.22.0"
+    regexpu-core "^2.0.0"
+
+babel-plugin-transform-exponentiation-operator@^6.22.0, babel-plugin-transform-exponentiation-operator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"
+  integrity sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=
+  dependencies:
+    babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
+    babel-plugin-syntax-exponentiation-operator "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-flow-strip-types@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
+  integrity sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=
+  dependencies:
+    babel-plugin-syntax-flow "^6.18.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-for-of-as-array@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-for-of-as-array/-/babel-plugin-transform-for-of-as-array-1.1.1.tgz#f18fcbcbfa2b8caed1445c3153893d37439a6537"
+  integrity sha512-eE4hZJhOUKpX0q/X3adR8B4hLox+t8oe4ZqmhANUmv4cds07AbWt6O0rtFXK7PKFPPnW4nz/5mpbkPMkflyGeg==
+
+babel-plugin-transform-object-rest-spread@^6.22.0, babel-plugin-transform-object-rest-spread@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
   integrity sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=
@@ -3267,10 +3907,107 @@ babel-plugin-transform-object-rest-spread@^6.26.0:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.26.0"
 
+babel-plugin-transform-react-display-name@^6.23.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz#67e2bf1f1e9c93ab08db96792e05392bf2cc28d1"
+  integrity sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-jsx-self@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz#df6d80a9da2612a121e6ddd7558bcbecf06e636e"
+  integrity sha1-322AqdomEqEh5t3XVYvL7PBuY24=
+  dependencies:
+    babel-plugin-syntax-jsx "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-jsx-source@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz#66ac12153f5cd2d17b3c19268f4bf0197f44ecd6"
+  integrity sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=
+  dependencies:
+    babel-plugin-syntax-jsx "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-jsx@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz#840a028e7df460dfc3a2d29f0c0d91f6376e66a3"
+  integrity sha1-hAoCjn30YN/DotKfDA2R9jduZqM=
+  dependencies:
+    babel-helper-builder-react-jsx "^6.24.1"
+    babel-plugin-syntax-jsx "^6.8.0"
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-react-remove-prop-types@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
   integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
+
+babel-plugin-transform-regenerator@^6.22.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
+  integrity sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=
+  dependencies:
+    regenerator-transform "^0.10.0"
+
+babel-plugin-transform-runtime@^6.22.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  integrity sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-strict-mode@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
+  integrity sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-preset-env@^1.1.8:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
+  integrity sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==
+  dependencies:
+    babel-plugin-check-es2015-constants "^6.22.0"
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-to-generator "^6.22.0"
+    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoping "^6.23.0"
+    babel-plugin-transform-es2015-classes "^6.23.0"
+    babel-plugin-transform-es2015-computed-properties "^6.22.0"
+    babel-plugin-transform-es2015-destructuring "^6.23.0"
+    babel-plugin-transform-es2015-duplicate-keys "^6.22.0"
+    babel-plugin-transform-es2015-for-of "^6.23.0"
+    babel-plugin-transform-es2015-function-name "^6.22.0"
+    babel-plugin-transform-es2015-literals "^6.22.0"
+    babel-plugin-transform-es2015-modules-amd "^6.22.0"
+    babel-plugin-transform-es2015-modules-commonjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-systemjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-umd "^6.23.0"
+    babel-plugin-transform-es2015-object-super "^6.22.0"
+    babel-plugin-transform-es2015-parameters "^6.23.0"
+    babel-plugin-transform-es2015-shorthand-properties "^6.22.0"
+    babel-plugin-transform-es2015-spread "^6.22.0"
+    babel-plugin-transform-es2015-sticky-regex "^6.22.0"
+    babel-plugin-transform-es2015-template-literals "^6.22.0"
+    babel-plugin-transform-es2015-typeof-symbol "^6.23.0"
+    babel-plugin-transform-es2015-unicode-regex "^6.22.0"
+    babel-plugin-transform-exponentiation-operator "^6.22.0"
+    babel-plugin-transform-regenerator "^6.22.0"
+    browserslist "^3.2.6"
+    invariant "^2.2.2"
+    semver "^5.3.0"
+
+babel-preset-flow@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz#e71218887085ae9a24b5be4169affb599816c49d"
+  integrity sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=
+  dependencies:
+    babel-plugin-transform-flow-strip-types "^6.22.0"
 
 babel-preset-jest@^24.9.0:
   version "24.9.0"
@@ -3301,13 +4038,102 @@ babel-preset-react-app@^9.1.2:
     babel-plugin-macros "2.8.0"
     babel-plugin-transform-react-remove-prop-types "0.4.24"
 
-babel-runtime@^6.26.0:
+babel-preset-react@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-react/-/babel-preset-react-6.24.1.tgz#ba69dfaea45fc3ec639b6a4ecea6e17702c91380"
+  integrity sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=
+  dependencies:
+    babel-plugin-syntax-jsx "^6.3.13"
+    babel-plugin-transform-react-display-name "^6.23.0"
+    babel-plugin-transform-react-jsx "^6.24.1"
+    babel-plugin-transform-react-jsx-self "^6.22.0"
+    babel-plugin-transform-react-jsx-source "^6.22.0"
+    babel-preset-flow "^6.23.0"
+
+babel-preset-stage-2@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz#d9e2960fb3d71187f0e64eec62bc07767219bdc1"
+  integrity sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-plugin-transform-class-properties "^6.24.1"
+    babel-plugin-transform-decorators "^6.24.1"
+    babel-preset-stage-3 "^6.24.1"
+
+babel-preset-stage-3@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz#836ada0a9e7a7fa37cb138fb9326f87934a48395"
+  integrity sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=
+  dependencies:
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-generator-functions "^6.24.1"
+    babel-plugin-transform-async-to-generator "^6.24.1"
+    babel-plugin-transform-exponentiation-operator "^6.24.1"
+    babel-plugin-transform-object-rest-spread "^6.22.0"
+
+babel-register@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
+  integrity sha1-btAhFz4vy0htestFxgCahW9kcHE=
+  dependencies:
+    babel-core "^6.26.0"
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    home-or-tmp "^2.0.0"
+    lodash "^4.17.4"
+    mkdirp "^0.5.1"
+    source-map-support "^0.4.15"
+
+babel-runtime@^5.8.34:
+  version "5.8.38"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-5.8.38.tgz#1c0b02eb63312f5f087ff20450827b425c9d4c19"
+  integrity sha1-HAsC62MxL18If/IEUIJ7QlydTBk=
+  dependencies:
+    core-js "^1.0.0"
+
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
+
+babel-template@^6.24.1, babel-template@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
+  integrity sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    lodash "^4.17.4"
+
+babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  integrity sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
+
+babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
 
 babylon@^6.18.0:
   version "6.18.0"
@@ -3319,7 +4145,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.1.2:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
@@ -3354,6 +4180,11 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+bin-v8-flags-filter@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/bin-v8-flags-filter/-/bin-v8-flags-filter-1.2.0.tgz#023fc4ee22999b2b1f6dd1b7253621366841537e"
+  integrity sha512-g8aeYkY7GhyyKRvQMBsJQZjhm2iCX3dKYvfrMpwVR8IxmUGrkpCBFoKbB9Rh0o3sTLCjU/1tFpZ4C7j3f+D+3g==
+
 binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
@@ -3378,7 +4209,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.5.5:
+bluebird@^3.5.0, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -3431,6 +4262,16 @@ bootstrap@^4.1.3:
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.0.tgz#97d9dbcb5a8972f8722c9962483543b907d9b9ec"
   integrity sha512-Z93QoXvodoVslA+PWNdk23Hze4RBYIkpb5h8I2HY2Tu2h7A0LpAgLcyrhrSUyo2/Oxm2l1fRZPs1e5hnxnliXA==
 
+bowser@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.6.0.tgz#37fc387b616cb6aef370dab4d6bd402b74c5c54d"
+  integrity sha1-N/w4e2Fstq7zcNq01r1AK3TFxU0=
+
+bowser@^2.8.1:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -3466,6 +4307,13 @@ brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
+
+brotli@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/brotli/-/brotli-1.3.2.tgz#525a9cad4fcba96475d7d388f6aecb13eed52f46"
+  integrity sha1-UlqcrU/LqWR119OI9q7LE+7VL0Y=
+  dependencies:
+    base64-js "^1.1.2"
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
@@ -3549,6 +4397,14 @@ browserslist@4.10.0:
     electron-to-chromium "^1.3.378"
     node-releases "^1.1.52"
     pkg-up "^3.1.0"
+
+browserslist@^3.2.6:
+  version "3.2.8"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
+  integrity sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==
+  dependencies:
+    caniuse-lite "^1.0.30000844"
+    electron-to-chromium "^1.3.47"
 
 browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.6.2, browserslist@^4.6.4, browserslist@^4.8.5, browserslist@^4.9.1:
   version "4.12.0"
@@ -3695,6 +4551,25 @@ caller-path@^2.0.0:
   dependencies:
     caller-callsite "^2.0.0"
 
+callsite-record@^4.0.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/callsite-record/-/callsite-record-4.1.3.tgz#3041d2a1c72aff86b00b151e47d25566520c4207"
+  integrity sha512-otAcPmu8TiHZ38cIL3NjQa1nGoSQRRe8WDDUgj5ZUwJWn1wzOYBwVSJbpVyzZ0sesQeKlYsPu9DG70fhh6AK9g==
+  dependencies:
+    "@types/error-stack-parser" "^1.3.18"
+    "@types/lodash" "^4.14.72"
+    callsite "^1.0.0"
+    chalk "^2.4.0"
+    error-stack-parser "^1.3.3"
+    highlight-es "^1.0.0"
+    lodash "4.6.1 || ^4.16.1"
+    pinkie-promise "^2.0.0"
+
+callsite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+  integrity sha1-KAOY5dZkvXQDi28JBRU+borxvCA=
+
 callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
@@ -3751,6 +4626,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, can
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001081.tgz#40615a3c416a047c5a4d45673e5257bf128eb3b5"
   integrity sha512-iZdh3lu09jsUtLE6Bp8NAbJskco4Y3UDtkR3GTCJGsbMowBU5IWDFF79sV2ws7lSqTzWyKazxam2thasHymENQ==
 
+caniuse-lite@^1.0.30000844:
+  version "1.0.30001154"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001154.tgz#f3bbc245ce55e4c1cd20fa731b097880181a7f17"
+  integrity sha512-y9DvdSti8NnYB9Be92ddMZQrcOe04kcQtcxtBx4NkB04+qZ+JUWotnXBJTmxlKudhxNTQ3RRknMwNU2YQl/Org==
+
 capital-case@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/capital-case/-/capital-case-1.0.3.tgz#339bd77e8fab6cf75111d4fca509b3edf7c117c8"
@@ -3785,7 +4665,19 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
+chai@^4.1.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
+  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.0"
+    type-detect "^4.0.5"
+
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -3849,6 +4741,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
+
 cheerio@^1.0.0-rc.3:
   version "1.0.0-rc.3"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
@@ -3900,12 +4797,30 @@ chownr@^1.1.1, chownr@^1.1.2:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+chrome-remote-interface@^0.25.3:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.25.7.tgz#827e85fbef3cc561a9ef2404eb7eee355968c5bc"
+  integrity sha512-6zI6LbR2IiGmduFZededaerEr9hHXabxT/L+fRrdq65a0CfyLMzpq0BKuZiqN0Upqcacsb6q2POj7fmobwBsEA==
+  dependencies:
+    commander "2.11.x"
+    ws "3.3.x"
+
 chrome-trace-event@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz#234090ee97c7d4ad1a2c4beae27505deffc608a4"
   integrity sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==
   dependencies:
     tslib "^1.9.0"
+
+chromium-pickle-js@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz#04a106672c18b085ab774d983dfa3ea138f22205"
+  integrity sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=
+
+ci-info@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+  integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -4156,6 +5071,11 @@ codecov@^3.7.0:
     teeny-request "6.0.1"
     urlgrey "0.4.4"
 
+coffeescript@^2.3.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/coffeescript/-/coffeescript-2.5.1.tgz#b2442a1f2c806139669534a54adc35010559d16a"
+  integrity sha512-J2jRPX0eeFh5VKyVnoLrfVFgLZtnnmp96WQSLAS8OrLm2wtQLcnikYKe1gViJKDH7vucjuhHvBKKBP3rKcD1tQ==
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -4216,7 +5136,12 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0, commander@^2.12.1, commander@^2.19.0, commander@^2.20.0:
+commander@2.11.x:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+  integrity sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==
+
+commander@^2.11.0, commander@^2.12.1, commander@^2.19.0, commander@^2.20.0, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -4344,7 +5269,7 @@ content-type@^1.0.4, content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-convert-source-map@1.7.0, convert-source-map@^1.4.0, convert-source-map@^1.7.0:
+convert-source-map@1.7.0, convert-source-map@^1.4.0, convert-source-map@^1.5.1, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
@@ -4401,7 +5326,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.4.0:
+core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
@@ -4530,6 +5455,11 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+crypto-md5@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-md5/-/crypto-md5-1.0.0.tgz#ccc8da750c753c7edcbabc542967472a384e86bb"
+  integrity sha1-zMjadQx1PH7curxUKWdHKjhOhrs=
+
 css-blank-pseudo@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz#dfdefd3254bf8a82027993674ccf35483bfcb3c5"
@@ -4633,6 +5563,16 @@ css-what@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.3.0.tgz#10fec696a9ece2e591ac772d759aacabac38cd39"
   integrity sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==
+
+css@2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.3.tgz#f861f4ba61e79bedc962aa548e5780fd95cbc6be"
+  integrity sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==
+  dependencies:
+    inherits "^2.0.1"
+    source-map "^0.1.38"
+    source-map-resolve "^0.5.1"
+    urix "^0.1.0"
 
 css@^2.0.0:
   version "2.2.4"
@@ -4751,6 +5691,11 @@ csstype@^2.2.0, csstype@^2.6.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
   integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
+cuint@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
+  integrity sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -4797,14 +5742,14 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@4, debug@4.1.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -4828,10 +5773,27 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+dedent@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.4.0.tgz#87defd040bd4c1595d963282ec57f3c2a8525642"
+  integrity sha1-h979BAvUwVldljKC7FfzwqhSVkI=
+
+dedent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.6.0.tgz#0e6da8f0ce52838ef5cec5c8f9396b0c1b64a3cb"
+  integrity sha1-Dm2o8M5Sg471zsXI+TlrDBtko8s=
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
+
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-equal@^1.0.1, deep-equal@^1.1.1:
   version "1.1.1"
@@ -4887,6 +5849,18 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+del@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
+  integrity sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=
+  dependencies:
+    globby "^6.1.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    p-map "^1.1.1"
+    pify "^3.0.0"
+    rimraf "^2.2.8"
+
 del@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/del/-/del-4.1.1.tgz#9e8f117222ea44a31ff3a156c049b99052a9f0b4"
@@ -4899,6 +5873,20 @@ del@^4.1.1:
     p-map "^2.0.0"
     pify "^4.0.1"
     rimraf "^2.6.3"
+
+del@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-5.1.0.tgz#d9487c94e367410e6eff2925ee58c0c84a75b3a7"
+  integrity sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==
+  dependencies:
+    globby "^10.0.1"
+    graceful-fs "^4.2.2"
+    is-glob "^4.0.1"
+    is-path-cwd "^2.2.0"
+    is-path-inside "^3.0.1"
+    p-map "^3.0.0"
+    rimraf "^3.0.0"
+    slash "^3.0.0"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -4928,6 +5916,13 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+detect-indent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
+  integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
+  dependencies:
+    repeating "^2.0.0"
+
 detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
@@ -4946,6 +5941,11 @@ detect-port-alt@1.1.6:
     address "^1.0.1"
     debug "^2.6.0"
 
+device-specs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/device-specs/-/device-specs-1.0.0.tgz#47b54577b9b159118bbb0a175177d0aa9c50a9c9"
+  integrity sha512-fYXbFSeilT7bnKWFi4OERSPHdtaEoDGn4aUhV5Nly6/I+Tp6JZ/6Icmd7LVIF5euyodGpxz2e/bfUmDnIdSIDw==
+
 diff-sequences@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
@@ -4956,7 +5956,7 @@ diff-sequences@^25.2.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
   integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
 
-diff@^4.0.1:
+diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
@@ -4976,6 +5976,13 @@ dir-glob@2.0.0:
   integrity sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==
   dependencies:
     arrify "^1.0.1"
+    path-type "^3.0.0"
+
+dir-glob@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
+  integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
+  dependencies:
     path-type "^3.0.0"
 
 dir-glob@^3.0.1:
@@ -5039,6 +6046,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.1:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
+  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -5186,6 +6198,11 @@ electron-to-chromium@^1.3.413:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.467.tgz#84eeb332134d49f0e49b88588824e56b20af9e27"
   integrity sha512-U+QgsL8TZDU/n+rDnYDa3hY5uy3C4iry9mrJS0PNBBGwnocuQ+aHSfgY44mdlaK9744X5YqrrGUvD9PxCLY1HA==
 
+electron-to-chromium@^1.3.47:
+  version "1.3.587"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.587.tgz#de570df7320eb259c0511f284c2d6008094edbf7"
+  integrity sha512-8XFNxzNj0R8HpTQslWAw6UWpGSuOKSP3srhyFHVbGUGb8vTHckZGCyWi+iQlaXJx5DNeTQTQLd6xN11WSckkmA==
+
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
@@ -5203,6 +6220,11 @@ elliptic@^6.0.0, elliptic@^6.5.2:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
+
+emittery@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.4.1.tgz#abe9d3297389ba424ac87e53d1c701962ce7433d"
+  integrity sha512-r4eRSeStEGf6M5SKdrQhhLK5bOwOBxQhIE3YSTnZE3GpKiLfnnhE+tPtrJE79+eDJgm39BM6LSoI8SCx4HbwlQ==
 
 emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   version "7.0.3"
@@ -5242,6 +6264,14 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+endpoint-utils@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/endpoint-utils/-/endpoint-utils-1.0.2.tgz#0808c3369a727cd7967a39ff34ebc926b88146a8"
+  integrity sha1-CAjDNppyfNeWejn/NOvJJriBRqg=
+  dependencies:
+    ip "^1.1.3"
+    pinkie-promise "^1.0.0"
 
 enhanced-resolve@^4.1.0:
   version "4.1.1"
@@ -5353,6 +6383,13 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+error-stack-parser@^1.3.3, error-stack-parser@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-1.3.6.tgz#e0e73b93e417138d1cd7c0b746b1a4a14854c292"
+  integrity sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=
+  dependencies:
+    stackframe "^0.3.1"
 
 es-abstract@^1.17.0, es-abstract@^1.17.4:
   version "1.17.5"
@@ -5638,6 +6675,13 @@ eslint@^6.6.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
+esotope-hammerhead@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/esotope-hammerhead/-/esotope-hammerhead-0.5.6.tgz#f846638bc10adf068642decdf54b9a9ac856ccfb"
+  integrity sha512-E5cJKuecAEt/psafJ8rBjAezBS5/5iqyzgzRPH2JWEhZYTRzkphX9c9djqpJj8Zcfv7PpqgNgXXbaqxgCIVsPw==
+  dependencies:
+    "@types/estree" "^0.0.39"
+
 espree@^6.1.2:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
@@ -5734,10 +6778,41 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^3.3.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-3.4.0.tgz#c08ed4550ef65d858fac269ffc8572446f37eb89"
+  integrity sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
+    onetime "^5.1.0"
+    p-finally "^2.0.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
 execa@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.2.tgz#ad87fb7b2d9d564f70d2b62d511bee41d5cbb240"
   integrity sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
+execa@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
+  integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
   dependencies:
     cross-spawn "^7.0.0"
     get-stream "^5.0.0"
@@ -5895,7 +6970,7 @@ fast-diff@^1.1.1:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-glob@^2.0.2:
+fast-glob@^2.0.2, fast-glob@^2.2.6:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
   integrity sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==
@@ -5907,7 +6982,7 @@ fast-glob@^2.0.2:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.1.1:
+fast-glob@^3.0.3, fast-glob@^3.1.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
   integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
@@ -6389,6 +7464,11 @@ get-caller-file@^2.0.0, get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
+
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
@@ -6529,6 +7609,11 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
+globals@^9.18.0:
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+  integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
+
 globby@8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-8.0.2.tgz#5697619ccd95c5275dbb2d6faa42087c1a941d8d"
@@ -6541,6 +7626,20 @@ globby@8.0.2:
     ignore "^3.3.5"
     pify "^3.0.0"
     slash "^1.0.0"
+
+globby@^10.0.1:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-10.0.2.tgz#277593e745acaa4646c3ab411289ec47a0392543"
+  integrity sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.0.3"
+    glob "^7.1.3"
+    ignore "^5.1.1"
+    merge2 "^1.2.3"
+    slash "^3.0.0"
 
 globby@^11.0.1:
   version "11.0.1"
@@ -6565,6 +7664,20 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+globby@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
+  integrity sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^1.0.2"
+    dir-glob "^2.2.2"
+    fast-glob "^2.2.6"
+    glob "^7.1.3"
+    ignore "^4.0.3"
+    pify "^4.0.1"
+    slash "^2.0.0"
+
 globule@^1.0.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/globule/-/globule-1.3.2.tgz#d8bdd9e9e4eef8f96e245999a5dee7eb5d8529c4"
@@ -6583,6 +7696,13 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+
+graphlib@^2.1.5:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-2.1.8.tgz#5761d414737870084c92ec7b5dbcb0592c9d35da"
+  integrity sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==
+  dependencies:
+    lodash "^4.17.15"
 
 graphql-tag@2.10.4:
   version "2.10.4"
@@ -6750,6 +7870,15 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+highlight-es@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/highlight-es/-/highlight-es-1.0.3.tgz#12abc300a27e686f6f18010134e3a5c6d2fe6930"
+  integrity sha512-s/SIX6yp/5S1p8aC/NRDC1fwEb+myGIfp8/TzZz0rtAv8fzsdX7vGl3Q1TrXCsczFq8DI3CBFBCySPClfBSdbg==
+  dependencies:
+    chalk "^2.4.0"
+    is-es2016-keyword "^1.0.0"
+    js-tokens "^3.0.0"
+
 history@^4.10.1, history@^4.7.2:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
@@ -6782,6 +7911,14 @@ hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
   dependencies:
     react-is "^16.7.0"
+
+home-or-tmp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
+  integrity sha1-42w/LSyufXRqhX440Y1fMqeILbg=
+  dependencies:
+    os-homedir "^1.0.0"
+    os-tmpdir "^1.0.1"
 
 hosted-git-info@^2.1.4:
   version "2.8.8"
@@ -7025,6 +8162,13 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.5.1.tgz#b2425d3c7b18f7219f2ca663d103bddb91718d64"
+  integrity sha512-ONHr16SQvKZNSqjQT9gy5z24Jw+uqfO02/ngBSBoqChZ+W8qXX7GPRa1RoUnzGADw8K63R1BXUMzarCVQBpY8Q==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
 icss-utils@^4.0.0, icss-utils@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-4.1.1.tgz#21170b53789ee27447c2f47dd683081403f9a467"
@@ -7061,12 +8205,12 @@ ignore@^3.3.5:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
   integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
-ignore@^4.0.6:
+ignore@^4.0.3, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.4:
+ignore@^5.1.1, ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
@@ -7111,6 +8255,11 @@ import-from@^2.1.0:
   dependencies:
     resolve-from "^3.0.0"
 
+import-lazy@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-3.1.0.tgz#891279202c8a2280fdbd6674dbd8da1a1dfc67cc"
+  integrity sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==
+
 import-local@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d"
@@ -7128,6 +8277,15 @@ in-publish@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.1.tgz#948b1a535c8030561cea522f73f78f4be357e00c"
   integrity sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==
+
+indent-string@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-1.2.2.tgz#db99bcc583eb6abbb1e48dcbb1999a986041cb6b"
+  integrity sha1-25m8xYPrarux5I3LsZmamGBBy2s=
+  dependencies:
+    get-stdin "^4.0.1"
+    minimist "^1.1.0"
+    repeating "^1.1.0"
 
 indent-string@^2.1.0:
   version "2.1.0"
@@ -7271,7 +8429,7 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
-ip@^1.1.0, ip@^1.1.5:
+ip@^1.1.0, ip@^1.1.3, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
@@ -7349,6 +8507,13 @@ is-callable@^1.1.4, is-callable@^1.1.5, is-callable@^1.2.0:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
   integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
 
+is-ci@^1.0.10:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
+  integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
+  dependencies:
+    ci-info "^1.5.0"
+
 is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
@@ -7415,6 +8580,11 @@ is-docker@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.0.0.tgz#2cb0df0e75e2d064fe1864c37cdeacb7b2dcf25b"
   integrity sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==
 
+is-es2016-keyword@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-es2016-keyword/-/is-es2016-keyword-1.0.0.tgz#f6e54e110c5e4f8d265e69d2ed0eaf8cf5f47718"
+  integrity sha1-9uVOEQxeT40mXmnS7Q6vjPX0dxg=
+
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -7426,6 +8596,11 @@ is-extendable@^1.0.1:
   integrity sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
   dependencies:
     is-plain-object "^2.0.4"
+
+is-extglob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
+  integrity sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=
 
 is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
@@ -7459,6 +8634,13 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
+is-glob@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
+  integrity sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=
+  dependencies:
+    is-extglob "^1.0.0"
+
 is-glob@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
@@ -7472,6 +8654,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-jquery-obj@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-jquery-obj/-/is-jquery-obj-0.1.1.tgz#e8d9cc9737b1ab0733b50303e33a38ed7cc2f60b"
+  integrity sha512-18toSebUVF7y717dgw/Dzn6djOCqrkiDp3MhB8P6TdKyCVkbD1ZwE7Uz8Hwx6hUPTvKjbyYH9ncXT4ts4qLaSA==
 
 is-number-object@^1.0.4:
   version "1.0.4"
@@ -7507,10 +8694,22 @@ is-observable@^1.1.0:
   dependencies:
     symbol-observable "^1.1.0"
 
-is-path-cwd@^2.0.0:
+is-path-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
+  integrity sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
+
+is-path-cwd@^2.0.0, is-path-cwd@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
   integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
+
+is-path-in-cwd@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
+  integrity sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==
+  dependencies:
+    is-path-inside "^1.0.0"
 
 is-path-in-cwd@^2.0.0:
   version "2.1.0"
@@ -7519,12 +8718,24 @@ is-path-in-cwd@^2.0.0:
   dependencies:
     is-path-inside "^2.1.0"
 
+is-path-inside@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
+  integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
+  dependencies:
+    path-is-inside "^1.0.1"
+
 is-path-inside@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-2.1.0.tgz#7c9810587d659a40d27bcdb4d5616eab059494b2"
   integrity sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==
   dependencies:
     path-is-inside "^1.0.2"
+
+is-path-inside@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
+  integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
 
 is-plain-obj@^1.0.0:
   version "1.1.0"
@@ -8147,15 +9358,15 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.2.tgz#313b6274dda718f714d00b3330bbae6e38e90209"
   integrity sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==
 
+js-tokens@^3.0.0, js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+  integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-
-js-tokens@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
-  integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
 js-yaml@3.13.1:
   version "3.13.1"
@@ -8242,6 +9453,11 @@ jsdom@^14.1.0:
     ws "^6.1.2"
     xml-name-validator "^3.0.0"
 
+jsesc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
+  integrity sha1-RsP+yMGJKxKwgz25vHYiF226s0s=
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -8289,6 +9505,11 @@ json3@^3.3.2:
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
   integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
+json5@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+  integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
@@ -8296,7 +9517,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.2:
+json5@^2.1.0, json5@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
@@ -8468,6 +9689,13 @@ lint-staged@^10.2.9:
     please-upgrade-node "^3.2.0"
     string-argv "0.3.1"
     stringify-object "^3.3.0"
+
+linux-platform-info@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/linux-platform-info/-/linux-platform-info-0.0.3.tgz#2dae324385e66e3d755bec83f86c7beea61ceb83"
+  integrity sha1-La4yQ4Xmbj11W+yD+Gx77qYc64M=
+  dependencies:
+    os-family "^1.0.0"
 
 listr-silent-renderer@^1.1.1:
   version "1.1.1"
@@ -8703,15 +9931,15 @@ lodash.xorby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.xorby/-/lodash.xorby-4.7.0.tgz#9c19a6f9f063a6eb53dd03c1b6871799801463d7"
   integrity sha1-nBmm+fBjputT3QPBtocXmYAUY9c=
 
+"lodash@4.6.1 || ^4.16.1", lodash@^4.14.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.4, lodash@~4.17.10:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
 "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.15, lodash@^4.17.5:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.19, lodash@~4.17.10:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -8726,6 +9954,16 @@ log-symbols@^4.0.0:
   integrity sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
   dependencies:
     chalk "^4.0.0"
+
+log-update-async-hook@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/log-update-async-hook/-/log-update-async-hook-2.0.2.tgz#6eba89dbe67fa12d0b20ac47df7942947af1fcd1"
+  integrity sha512-HQwkKFTZeUOrDi1Duf2CSUa/pSpcaCHKLdx3D/Z16DsipzByOBffcg5y0JZA1q0n80dYgLXe2hFM9JGNgBsTDw==
+  dependencies:
+    ansi-escapes "^2.0.0"
+    async-exit-hook "^1.1.2"
+    onetime "^2.0.1"
+    wrap-ansi "^2.1.0"
 
 log-update@^2.3.0:
   version "2.3.0"
@@ -8773,6 +10011,11 @@ lower-case@^2.0.1:
   dependencies:
     tslib "^1.10.0"
 
+lru-cache@2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.6.3.tgz#51ccd0b4fc0c843587d7a5709ce4d3b7629bedc5"
+  integrity sha1-UczQtPwMhDWH16VwnOTTt2Kb7cU=
+
 lru-cache@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
@@ -8788,6 +10031,11 @@ lru-cache@^5.0.0, lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -8796,7 +10044,7 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.2:
+make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -8837,12 +10085,24 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
   integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
 
+map-reverse@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/map-reverse/-/map-reverse-1.0.1.tgz#274e9f500a611153183b5b8d8490a9c1c23ee310"
+  integrity sha1-J06fUAphEVMYO1uNhJCpwcI+4xA=
+
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+match-url-wildcard@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/match-url-wildcard/-/match-url-wildcard-0.0.4.tgz#c8533da7ec0901eddf01fc0893effa68d4e727d6"
+  integrity sha512-R1XhQaamUZPWLOPtp4ig5j+3jctN+skhgRmEQTUamMzmNtRG69QEirQs0NZKLtHMR7tzWpmtnS4Eqv65DcgXUA==
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -8923,6 +10183,13 @@ merge-descriptors@1.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
+merge-stream@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
+  integrity sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=
+  dependencies:
+    readable-stream "^2.0.1"
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -8983,6 +10250,11 @@ mime-db@1.44.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
+mime-db@^1.41.0:
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
+  integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
+
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.27"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
@@ -8999,6 +10271,11 @@ mime@^2.4.4:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
   integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
+
+mime@~1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
+  integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -9037,7 +10314,7 @@ minimatch@3.0.4, minimatch@^3.0.4, minimatch@~3.0.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -9109,10 +10386,20 @@ mkdirp@0.5.5, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkd
   dependencies:
     minimist "^1.2.5"
 
+moment-duration-format-commonjs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/moment-duration-format-commonjs/-/moment-duration-format-commonjs-1.0.0.tgz#dc5de612e6d6ff41f774d03772a139a363563bc3"
+  integrity sha512-MVFR4hIh4jfuwSCPBEE5CCwn3refvTsxK/Yv/DpKJ6YcNnCimlVJ6DQeTJG1KVQPw1o8m3tkbHE9gVjivyv9iA==
+
 moment@2.27.0, moment@^2.22.1:
   version "2.27.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
   integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
+
+moment@^2.10.3, moment@^2.14.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 moo@^0.5.0:
   version "0.5.1"
@@ -9159,6 +10446,11 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
+mustache@^2.1.1, mustache@^2.1.2, mustache@^2.2.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
+  integrity sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==
+
 mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
@@ -9168,6 +10460,21 @@ nan@^2.12.1, nan@^2.13.2:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
+
+nanoid@^1.0.1:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-1.3.4.tgz#ad89f62c9d1f4fd69710d4a90953d2893d2d31f4"
+  integrity sha512-4ug4BsuHxiVHoRUe1ud6rUFT3WUMmjXt1W0quL0CviZQANdan7D8kqN5/maw53hmAApY/jfzMRkC57BNNs60ZQ==
+
+nanoid@^2.1.3:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
+  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
+
+nanoid@^3.1.12:
+  version "3.1.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"
+  integrity sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -9348,6 +10655,11 @@ node-sass@^4.14.1:
     sass-graph "2.2.5"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
+
+node-version@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/node-version/-/node-version-1.2.0.tgz#34fde3ffa8e1149bd323983479dda620e1b5060d"
+  integrity sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ==
 
 "nopt@2 || 3":
   version "3.0.6"
@@ -9588,7 +10900,7 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^2.0.0:
+onetime@^2.0.0, onetime@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
@@ -9668,6 +10980,11 @@ os-browserify@^0.3.0:
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
 
+os-family@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/os-family/-/os-family-1.1.0.tgz#8a89cb617dd1631b8ef9506be830144f626c214e"
+  integrity sha512-E3Orl5pvDJXnVmpaAA2TeNNpNhTMl4o5HghuWhOivBjEiTnJSrMYSa5uZMek1lBEvu8kKEsa2YgVcGFVDqX/9w==
+
 os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
@@ -9682,7 +10999,7 @@ os-locale@^3.0.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -9711,6 +11028,11 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
+p-finally@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-2.0.1.tgz#bd6fcaa9c559a096b680806f4d657b3f0f240561"
+  integrity sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==
 
 p-is-promise@^2.0.0:
   version "2.1.0"
@@ -9751,6 +11073,11 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-map@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+  integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
 
 p-map@^2.0.0:
   version "2.1.0"
@@ -9877,6 +11204,11 @@ parse-url@^5.0.0:
     parse-path "^4.0.0"
     protocols "^1.4.0"
 
+parse5@2.2.3, parse5@^2.1.5:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-2.2.3.tgz#0c4fc41c1000c5e6b93d48b03f8083837834e9f6"
+  integrity sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=
+
 parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
@@ -9886,6 +11218,11 @@ parse5@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
   integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
+
+parse5@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+  integrity sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=
 
 parse5@^3.0.1:
   version "3.0.3"
@@ -9955,12 +11292,12 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
-path-is-absolute@^1.0.0:
+path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-is-inside@^1.0.2:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
@@ -10020,6 +11357,11 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathval@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
+
 pbkdf2@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"
@@ -10041,7 +11383,7 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
-pify@^2.0.0:
+pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
@@ -10056,6 +11398,13 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
+pinkie-promise@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-1.0.0.tgz#d1da67f5482563bb7cf57f286ae2822ecfbf3670"
+  integrity sha1-0dpn9UglY7t89X8oauKCLs+/NnA=
+  dependencies:
+    pinkie "^1.0.0"
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -10063,10 +11412,15 @@ pinkie-promise@^2.0.0:
   dependencies:
     pinkie "^2.0.0"
 
-pinkie@^2.0.0:
+pinkie@2.0.4, pinkie@^2.0.0, pinkie@^2.0.1, pinkie@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
+
+pinkie@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-1.0.0.tgz#5a47f28ba1015d0201bda7bf0f358e47bec8c7e4"
+  integrity sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=
 
 pirates@^4.0.1:
   version "4.0.1"
@@ -10136,6 +11490,11 @@ pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
+
+pngjs@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
+  integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
 
 pnp-webpack-plugin@1.6.4:
   version "1.6.4"
@@ -10872,7 +12231,17 @@ pretty-format@^25.2.1, pretty-format@^25.5.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
-private@^0.1.8:
+pretty-format@^26.4.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
+private@^0.1.6, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
@@ -10910,6 +12279,13 @@ promise@^8.0.3:
   integrity sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==
   dependencies:
     asap "~2.0.6"
+
+promisify-event@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/promisify-event/-/promisify-event-1.0.0.tgz#bd7523ea06b70162f370979016b53a686c60e90f"
+  integrity sha1-vXUj6ga3AWLzcJeQFrU6aGxg6Q8=
+  dependencies:
+    pinkie-promise "^2.0.0"
 
 prompts@^2.0.1:
   version "2.3.2"
@@ -11007,7 +12383,7 @@ punycode@1.3.2:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
-punycode@^1.2.4:
+punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
@@ -11021,6 +12397,11 @@ q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
+
+qrcode-terminal@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.10.0.tgz#a76a48e2610a18f97fa3a2bd532b682acff86c53"
+  integrity sha1-p2pI4mEKGPl/o6K9UytoKs/4bFM=
 
 qs@6.7.0:
   version "6.7.0"
@@ -11204,6 +12585,11 @@ react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.2, react-i
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-is@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
+
 react-leaflet@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/react-leaflet/-/react-leaflet-2.7.0.tgz#0e0e452a4903029f0bb564771eab8cf9db8e4517"
@@ -11379,6 +12765,13 @@ reactstrap@8.4.1:
     react-lifecycles-compat "^3.0.4"
     react-popper "^1.3.6"
     react-transition-group "^2.3.1"
+
+read-file-relative@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/read-file-relative/-/read-file-relative-1.2.0.tgz#98f7d96eaa21d2b4c7a2febd63d2fc8cf35e9f9b"
+  integrity sha1-mPfZbqoh0rTHov69Y9L8jPNen5s=
+  dependencies:
+    callsite "^1.0.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -11588,6 +12981,11 @@ regenerate-unicode-properties@^8.2.0:
   dependencies:
     regenerate "^1.4.0"
 
+regenerate@^1.2.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
+  integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
+
 regenerate@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.1.tgz#cad92ad8e6b591773485fbe05a485caf4f457e6f"
@@ -11602,6 +13000,15 @@ regenerator-runtime@^0.13.3, regenerator-runtime@^0.13.4:
   version "0.13.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
   integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
+
+regenerator-transform@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
+  integrity sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==
+  dependencies:
+    babel-runtime "^6.18.0"
+    babel-types "^6.19.0"
+    private "^0.1.6"
 
 regenerator-transform@^0.14.2:
   version "0.14.4"
@@ -11642,6 +13049,15 @@ regexpp@^3.0.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
 
+regexpu-core@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
+  integrity sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=
+  dependencies:
+    regenerate "^1.2.1"
+    regjsgen "^0.2.0"
+    regjsparser "^0.1.4"
+
 regexpu-core@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.7.0.tgz#fcbf458c50431b0bb7b45d6967b8192d91f3d938"
@@ -11654,10 +13070,22 @@ regexpu-core@^4.7.0:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.2.0"
 
+regjsgen@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7"
+  integrity sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=
+
 regjsgen@^0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.2.tgz#92ff295fb1deecbf6ecdab2543d207e91aa33733"
   integrity sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==
+
+regjsparser@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c"
+  integrity sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=
+  dependencies:
+    jsesc "~0.5.0"
 
 regjsparser@^0.6.4:
   version "0.6.4"
@@ -11697,12 +13125,24 @@ repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
+repeating@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/repeating/-/repeating-1.1.3.tgz#3d4114218877537494f97f77f9785fab810fa4ac"
+  integrity sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=
+  dependencies:
+    is-finite "^1.0.0"
+
 repeating@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
+
+replicator@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/replicator/-/replicator-1.0.3.tgz#c0b3ea31e749015bae5d52273f2ae35d541b87ef"
+  integrity sha512-WsKsraaM0x0QHy5CtzdgFXUxyowoBhyNkmPqmZShW6h+rOWnyT6Od3zRdTX9r616rAA6kDC9MKQGnSM/CJKfVQ==
 
 request-promise-core@1.1.3:
   version "1.1.3"
@@ -11766,12 +13206,24 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+resolve-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-1.0.0.tgz#4eaeea41ed040d1702457df64a42b2b07d246f9f"
+  integrity sha1-Tq7qQe0EDRcCRX32SkKysH0kb58=
+  dependencies:
+    resolve-from "^2.0.0"
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
   integrity sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=
   dependencies:
     resolve-from "^3.0.0"
+
+resolve-from@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+  integrity sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=
 
 resolve-from@^3.0.0:
   version "3.0.0"
@@ -11882,7 +13334,7 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@2, rimraf@^2.5.4, rimraf@^2.6.3, rimraf@^2.7.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -11893,6 +13345,13 @@ rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -11984,6 +13443,13 @@ sane@^4.0.3:
     micromatch "^3.1.4"
     minimist "^1.1.1"
     walker "~1.0.5"
+
+sanitize-filename@^1.6.0:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.3.tgz#755ebd752045931977e30b2025d340d7c9090378"
+  integrity sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==
+  dependencies:
+    truncate-utf8-bytes "^1.0.0"
 
 sanitize.css@^10.0.0:
   version "10.0.0"
@@ -12083,6 +13549,11 @@ semver-regex@^2.0.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+
+semver@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
 
 semver@6.3.0, semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
@@ -12407,7 +13878,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.1, source-map-resolve@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
   integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==
@@ -12418,7 +13889,14 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12:
+source-map-support@^0.4.15:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+  integrity sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
+  dependencies:
+    source-map "^0.5.6"
+
+source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -12436,6 +13914,13 @@ source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, sourc
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+source-map@^0.1.38:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  integrity sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=
+  dependencies:
+    amdefine ">=0.0.4"
+
 source-map@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -12443,7 +13928,7 @@ source-map@^0.4.2:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.6:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -12553,6 +14038,11 @@ stack-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
+
+stackframe@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
+  integrity sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -13014,6 +14504,183 @@ test-exclude@^5.2.3:
     read-pkg-up "^4.0.0"
     require-main-filename "^2.0.0"
 
+testcafe-browser-tools@2.0.13:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/testcafe-browser-tools/-/testcafe-browser-tools-2.0.13.tgz#1b185539d64991ad0a4da11992beeb6b4bd5ba9d"
+  integrity sha512-r0AfCNsOJWXHAR+KADumfCffsH3LYoEbJXfmGOG47uEt1FBEw8cWTSWRBp5As+DaAmh9pi75P+ZF6K09WudM/g==
+  dependencies:
+    array-find "^1.0.0"
+    dedent "^0.7.0"
+    del "^5.1.0"
+    execa "^3.3.0"
+    graceful-fs "^4.1.11"
+    linux-platform-info "^0.0.3"
+    lodash "^4.17.15"
+    mkdirp "^0.5.1"
+    mustache "^2.1.2"
+    nanoid "^2.1.3"
+    os-family "^1.0.0"
+    pify "^2.3.0"
+    pinkie "^2.0.1"
+    read-file-relative "^1.2.0"
+    which-promise "^1.0.0"
+
+testcafe-hammerhead@17.1.20:
+  version "17.1.20"
+  resolved "https://registry.yarnpkg.com/testcafe-hammerhead/-/testcafe-hammerhead-17.1.20.tgz#eed2eeb938ad1ca5e7a41c55e3e6e135bf599df2"
+  integrity sha512-1Z1r+cUjn0Cg3/Q8uwUYGeL+UvKPXAtYtiOqdGKM8/nXxndxc+q3KBvmBZXSUE9rAWhn3Mb3SQ8LoSw1+iQyiA==
+  dependencies:
+    acorn-hammerhead "^0.3.0"
+    asar "^2.0.1"
+    bowser "1.6.0"
+    brotli "^1.3.1"
+    crypto-md5 "^1.0.0"
+    css "2.2.3"
+    debug "4.1.1"
+    esotope-hammerhead "0.5.6"
+    iconv-lite "0.5.1"
+    lodash "^4.17.19"
+    lru-cache "2.6.3"
+    match-url-wildcard "0.0.4"
+    merge-stream "^1.0.1"
+    mime "~1.4.1"
+    mustache "^2.1.1"
+    nanoid "^3.1.12"
+    os-family "^1.0.0"
+    parse5 "2.2.3"
+    pinkie "2.0.4"
+    read-file-relative "^1.2.0"
+    semver "5.5.0"
+    tough-cookie "2.3.3"
+    tunnel-agent "0.6.0"
+    webauth "^1.1.0"
+
+testcafe-legacy-api@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/testcafe-legacy-api/-/testcafe-legacy-api-4.0.0.tgz#700bacce8d16028250d41b643051645b4cfe7cd5"
+  integrity sha512-Tn+YEH8hqDPQs/1/d+A9G+FdfejougtoWX0wRxrLq5ECYy2qxwH8p9EGDUNatLm0IFIumVpcz2tSZkvRpfKLSg==
+  dependencies:
+    async "0.2.6"
+    babel-runtime "^5.8.34"
+    dedent "^0.6.0"
+    highlight-es "^1.0.0"
+    is-jquery-obj "^0.1.0"
+    lodash "^4.14.0"
+    moment "^2.14.1"
+    mustache "^2.2.1"
+    os-family "^1.0.0"
+    parse5 "^2.1.5"
+    pify "^2.3.0"
+    pinkie "^2.0.1"
+    strip-bom "^2.0.0"
+
+testcafe-reporter-json@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/testcafe-reporter-json/-/testcafe-reporter-json-2.2.0.tgz#bb061e054489abdb62add745dd979896b618ea91"
+  integrity sha512-wfpNaZgGP2WoqdmnIXOyxcpwSzdH1HvzXSN397lJkXOrQrwhuGUThPDvyzPnZqxZSzXdDUvIPJm55tCMWbfymQ==
+
+testcafe-reporter-list@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/testcafe-reporter-list/-/testcafe-reporter-list-2.1.0.tgz#9fa89f71b97d3dfe64b4302d5e227dee69aec6b9"
+  integrity sha1-n6ifcbl9Pf5ktDAtXiJ97mmuxrk=
+
+testcafe-reporter-minimal@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/testcafe-reporter-minimal/-/testcafe-reporter-minimal-2.1.0.tgz#676f03547634143c6eaf3ab52868273a4bebf421"
+  integrity sha1-Z28DVHY0FDxurzq1KGgnOkvr9CE=
+
+testcafe-reporter-spec@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/testcafe-reporter-spec/-/testcafe-reporter-spec-2.1.1.tgz#8156fced0f5132486559ad560bc80676469275ec"
+  integrity sha1-gVb87Q9RMkhlWa1WC8gGdkaSdew=
+
+testcafe-reporter-xunit@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/testcafe-reporter-xunit/-/testcafe-reporter-xunit-2.1.0.tgz#e6d66c572ce15af266706af0fd610b2a841dd443"
+  integrity sha1-5tZsVyzhWvJmcGrw/WELKoQd1EM=
+
+testcafe@^1.9.4:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/testcafe/-/testcafe-1.9.4.tgz#a9fb9981e15cbbd559a93429adad527259921a9c"
+  integrity sha512-tiG0a47vvwuI6xle002wQitpEGG3Oi+qJOjFAgXT7rPYzcHrPRYP2rgefvCw/VE/qsGRHzyvDDYH3FbQMojDAA==
+  dependencies:
+    "@types/node" "^10.12.19"
+    async-exit-hook "^1.1.2"
+    babel-core "^6.22.1"
+    babel-plugin-transform-class-properties "^6.24.1"
+    babel-plugin-transform-for-of-as-array "^1.1.1"
+    babel-plugin-transform-runtime "^6.22.0"
+    babel-preset-env "^1.1.8"
+    babel-preset-flow "^6.23.0"
+    babel-preset-react "^6.24.1"
+    babel-preset-stage-2 "^6.22.0"
+    babel-runtime "^6.22.0"
+    bin-v8-flags-filter "^1.1.2"
+    bowser "^2.8.1"
+    callsite "^1.0.0"
+    callsite-record "^4.0.0"
+    chai "^4.1.2"
+    chalk "^2.3.0"
+    chrome-remote-interface "^0.25.3"
+    coffeescript "^2.3.1"
+    commander "^2.8.1"
+    debug "^2.2.0"
+    dedent "^0.4.0"
+    del "^3.0.0"
+    device-specs "^1.0.0"
+    diff "^4.0.2"
+    elegant-spinner "^1.0.1"
+    emittery "^0.4.1"
+    endpoint-utils "^1.0.2"
+    error-stack-parser "^1.3.6"
+    execa "^4.0.3"
+    globby "^9.2.0"
+    graceful-fs "^4.1.11"
+    graphlib "^2.1.5"
+    import-lazy "^3.1.0"
+    indent-string "^1.2.2"
+    is-ci "^1.0.10"
+    is-docker "^2.0.0"
+    is-glob "^2.0.1"
+    is-stream "^1.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
+    log-update-async-hook "^2.0.2"
+    make-dir "^3.0.0"
+    map-reverse "^1.0.1"
+    mime-db "^1.41.0"
+    moment "^2.10.3"
+    moment-duration-format-commonjs "^1.0.0"
+    mustache "^2.1.2"
+    nanoid "^1.0.1"
+    node-version "^1.0.0"
+    os-family "^1.0.0"
+    parse5 "^1.5.0"
+    pify "^2.3.0"
+    pinkie "^2.0.4"
+    pngjs "^3.3.1"
+    promisify-event "^1.0.0"
+    qrcode-terminal "^0.10.0"
+    read-file-relative "^1.2.0"
+    replicator "^1.0.3"
+    resolve-cwd "^1.0.0"
+    resolve-from "^4.0.0"
+    sanitize-filename "^1.6.0"
+    source-map-support "^0.5.16"
+    strip-bom "^2.0.0"
+    testcafe-browser-tools "2.0.13"
+    testcafe-hammerhead "17.1.20"
+    testcafe-legacy-api "4.0.0"
+    testcafe-reporter-json "^2.1.0"
+    testcafe-reporter-list "^2.1.0"
+    testcafe-reporter-minimal "^2.1.0"
+    testcafe-reporter-spec "^2.1.1"
+    testcafe-reporter-xunit "^2.1.0"
+    time-limit-promise "^1.0.2"
+    tmp "0.0.28"
+    tree-kill "^1.1.0"
+    typescript "^3.3.3"
+
 text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -13042,6 +14709,11 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
+time-limit-promise@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/time-limit-promise/-/time-limit-promise-1.0.4.tgz#33e928212273c70d52153c28ad2a7e3319b975f9"
+  integrity sha512-FLHDDsIDducw7MBcRWlFtW2Tm50DoKOSFf0Nzx17qwXj8REXCte0eUkHrJl9QU3Bl9arG3XNYX0PcHpZ9xyuLw==
+
 timers-browserify@^2.0.4:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"
@@ -13063,6 +14735,28 @@ tiny-warning@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
+tmp-promise@^1.0.5:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-1.1.0.tgz#bb924d239029157b9bc1d506a6aa341f8b13e64c"
+  integrity sha512-8+Ah9aB1IRXCnIOxXZ0uFozV1nMU5xiu7hhFVUSxZ3bYu+psD4TzagCzVbexUCgNNGJnsmNDQlS4nG3mTyoNkw==
+  dependencies:
+    bluebird "^3.5.0"
+    tmp "0.1.0"
+
+tmp@0.0.28:
+  version "0.0.28"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.28.tgz#172735b7f614ea7af39664fa84cf0de4e515d120"
+  integrity sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=
+  dependencies:
+    os-tmpdir "~1.0.1"
+
+tmp@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
+  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
+  dependencies:
+    rimraf "^2.6.3"
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -13087,6 +14781,11 @@ to-camel-case@^1.0.0:
   integrity sha1-GlYFSy+daWKYzmamCJcyK29CPkY=
   dependencies:
     to-space-case "^1.0.0"
+
+to-fast-properties@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+  integrity sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -13142,6 +14841,13 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+tough-cookie@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
+  integrity sha1-C2GKVWW23qkL80JdBNVe3EdadWE=
+  dependencies:
+    punycode "^1.4.1"
+
 tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@^2.5.0, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
@@ -13157,6 +14863,11 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+tree-kill@^1.1.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
 treeify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/treeify/-/treeify-1.1.0.tgz#4e31c6a463accd0943879f30667c4fdaff411bb8"
@@ -13167,12 +14878,24 @@ trim-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
 
+trim-right@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+  integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
 "true-case-path@^1.0.2":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-1.0.3.tgz#f813b5a8c86b40da59606722b144e3225799f47d"
   integrity sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==
   dependencies:
     glob "^7.1.2"
+
+truncate-utf8-bytes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
+  integrity sha1-QFkjkJWS1W94pYGENLC3hInKXys=
+  dependencies:
+    utf8-byte-length "^1.0.1"
 
 ts-essentials@^6.0.5:
   version "6.0.5"
@@ -13327,7 +15050,7 @@ tty@1.0.1:
   resolved "https://registry.yarnpkg.com/tty/-/tty-1.0.1.tgz#e4409ac98b0dd1c50b59ff38e86eac3f0764ee45"
   integrity sha1-5ECayYsN0cULWf846G6sPwdk7kU=
 
-tunnel-agent@^0.6.0:
+tunnel-agent@0.6.0, tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
@@ -13345,6 +15068,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.11.0:
   version "0.11.0"
@@ -13389,6 +15117,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^3.3.3:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
 typescript@^3.9.5:
   version "3.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
@@ -13398,6 +15131,11 @@ ua-parser-js@^0.7.18:
   version "0.7.21"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
   integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
+
+ultron@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+  integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -13554,6 +15292,11 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+utf8-byte-length@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
+  integrity sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
@@ -13752,6 +15495,11 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
+webauth@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/webauth/-/webauth-1.1.0.tgz#64704f6b8026986605bc3ca629952e6e26fdd100"
+  integrity sha1-ZHBPa4AmmGYFvDymKZUubib90QA=
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
@@ -13921,7 +15669,16 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
-which@1, which@^1.2.9, which@^1.3.0, which@^1.3.1:
+which-promise@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-promise/-/which-promise-1.0.0.tgz#20b721df05b35b706176ffa10b0909aba4603035"
+  integrity sha1-ILch3wWzW3Bhdv+hCwkJq6RgMDU=
+  dependencies:
+    pify "^2.2.0"
+    pinkie-promise "^1.0.0"
+    which "^1.1.2"
+
+which@1, which@^1.1.2, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -14110,7 +15867,7 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
-wrap-ansi@^2.0.0:
+wrap-ansi@^2.0.0, wrap-ansi@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
   integrity sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=
@@ -14182,6 +15939,15 @@ write@1.0.3:
   integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
   dependencies:
     mkdirp "^0.5.1"
+
+ws@3.3.x:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
+  integrity sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
+    ultron "~1.1.0"
 
 ws@^5.2.0:
   version "5.2.2"


### PR DESCRIPTION
## Description :sparkles:

Added TestCafe browser tests for
* Navigation and language switching
* Form filling (without sending)
  * New berth application, registered boat, private customer
  * Winter storage application, registered boat on trailer, private customer
  * Unmarked winter storage notice, registered boat on trailer, private customer

Note: Missing cron job from Travis

## Issues :bug:

### Closes :no_good_woman:

* [VEN-808](https://helsinkisolutionoffice.atlassian.net/browse/VEN-808): Implement happy path E2E tests for customer UI

## Testing :alembic:

### Automated tests :gear:️

* Browser tests can be executed locally by first running the `start` npm script, and then running the `browser-test:local` npm script in another terminal
