### PR TITLE
VEN-976 | Add contract signing step to payment flow

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
 SASS_PATH=src/assets:node_modules/open-city-design/src/scss
 REACT_APP_API_URL=https://venepaikka-api.test.hel.ninja/graphql/
+REACT_APP_API_URL_ROOT=https://venepaikka-api.test.kuva.hel.ninja/
 REACT_APP_PREFILLED_FORMS=false
 REACT_APP_MAX_SELECTED_BERTHS=10
 REACT_APP_SENTRY_DSN=https://id1@sentry.io/id2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ build-review:
   variables:
     DOCKER_IMAGE_NAME: '$CI_PROJECT_NAME-review'
     DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://venepaikka-api.test.kuva.hel.ninja/graphql/'
+    DOCKER_BUILD_ARG_REACT_APP_API_URL_ROOT: 'https://venepaikka-api.test.kuva.hel.ninja/'
     DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'development'
     DOCKER_BUILD_ARG_REACT_APP_SENTRY_ENVIRONMENT: 'review'
   only:
@@ -26,6 +27,7 @@ build-staging:
   variables:
     DOCKER_IMAGE_NAME: '$CI_PROJECT_NAME-staging'
     DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://venepaikka-api.test.kuva.hel.ninja/graphql/'
+    DOCKER_BUILD_ARG_REACT_APP_API_URL_ROOT: 'https://venepaikka-api.test.kuva.hel.ninja/'
     DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'development'
     DOCKER_BUILD_ARG_REACT_APP_SENTRY_ENVIRONMENT: 'staging'
   only:
@@ -37,6 +39,7 @@ build-production:
   variables:
     DOCKER_IMAGE_NAME: '$CI_PROJECT_NAME-production'
     DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://api.hel.fi/berths/graphql/'
+    DOCKER_BUILD_ARG_REACT_APP_API_URL_ROOT: 'https://api.hel.fi/berths/'
     DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'production'
     DOCKER_BUILD_ARG_REACT_APP_SENTRY_ENVIRONMENT: 'production'
   only:

--- a/src/__generated__/globalTypes.ts
+++ b/src/__generated__/globalTypes.ts
@@ -88,6 +88,13 @@ export interface ConfirmPaymentMutationInput {
   clientMutationId?: string | null;
 }
 
+export interface FulfillContractMutationInput {
+  orderNumber: string;
+  returnUrl: string;
+  authService: string;
+  clientMutationId?: string | null;
+}
+
 export interface HarborChoiceInput {
   harborId: string;
   priority: number;

--- a/src/components/pages/paymentPage/ContractPage.tsx
+++ b/src/components/pages/paymentPage/ContractPage.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Layout from '../../../common/layout/Layout';
+import { Button } from 'reactstrap';
+import './paymentPage.scss';
+import { Checkbox } from '../../forms/Fields';
+import { ContractAuthMethods_contractAuthMethods as ContractAuthMethods } from '../../../utils/__generated__/ContractAuthMethods';
+import Form from '../../forms/Form';
+import AuthButton from './authButton/AuthButton';
+
+interface Props {
+  orderNumber: string;
+  contractAuthMethods: ContractAuthMethods[];
+  handleSign: (authMethod: string) => void;
+}
+
+const PaymentPage = ({ contractAuthMethods, orderNumber, handleSign }: Props) => {
+  const { t } = useTranslation();
+  const [termsOpened, setTermsOpened] = useState<boolean>(false);
+  const [termsAccepted, setTermsAccepted] = useState<boolean>(false);
+
+  return (
+    <Layout>
+      <div id="vene-payment-page" className="vene-payment-page">
+        <div className="vene-payment-page__content-container">
+          <div className="vene-payment-page__content">
+            <h2>{t('page.contract.title')}</h2>
+            <p>{t('page.contract.info')}</p>
+            <p className="vene-payment-page__contact-info">
+              {t('page.contract.questions')}&nbsp;
+              <a href="mailto:venepaikat@hel.fi" className="vene-payment-page__link">
+                venepaikat@hel.fi
+              </a>
+            </p>
+          </div>
+        </div>
+        <div className="vene-payment-page__content-container">
+          <div className="vene-payment-page__content vene-payment-page__accept-terms-content">
+            <div>
+              <a
+                href={`${process.env.REACT_APP_API_URL_ROOT}contract_document/${orderNumber}`}
+                className="vene-payment-page__link"
+                rel="noopener noreferrer"
+                target="_blank"
+                onClick={() => setTermsOpened(true)}
+              >
+                {t('page.contract.terms_pdf')}
+              </a>
+            </div>
+
+            <Form
+              onSubmit={(values: { accepted: boolean }) => setTermsAccepted(values.accepted)}
+              initialValues={{}}
+            >
+              {({ values }: { values: { accepted: boolean } }) => (
+                <div>
+                  <Checkbox
+                    name={`accepted`}
+                    label="page.contract.terms_checkbox"
+                    value="accepted"
+                    disabled={!termsOpened || termsAccepted}
+                    required
+                  />
+                  {!termsAccepted && (
+                    <Button type="submit" color="primary" disabled={!values.accepted}>
+                      {t('page.contract.terms_form_submit')}
+                    </Button>
+                  )}
+                </div>
+              )}
+            </Form>
+
+            {termsAccepted && (
+              <div>
+                <h3>{t('page.contract.select_signing_provider')}</h3>
+                <div className="vene-payment-page__signing-providers">
+                  {contractAuthMethods.map((method, key) => (
+                    <AuthButton
+                      key={key}
+                      name={method.name}
+                      identifier={method.identifier}
+                      image={method.image}
+                      onClick={() => handleSign(method.identifier)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default PaymentPage;

--- a/src/components/pages/paymentPage/ContractPage.tsx
+++ b/src/components/pages/paymentPage/ContractPage.tsx
@@ -50,9 +50,9 @@ const PaymentPage = ({ contractAuthMethods, orderNumber, handleSign }: Props) =>
 
             <Form
               onSubmit={(values: { accepted: boolean }) => setTermsAccepted(values.accepted)}
-              initialValues={{}}
+              initialValues={{ accepted: false }}
             >
-              {({ values }: { values: { accepted: boolean } }) => (
+              {({ values }) => (
                 <div>
                   <Checkbox
                     name={`accepted`}

--- a/src/components/pages/paymentPage/PaymentPage.tsx
+++ b/src/components/pages/paymentPage/PaymentPage.tsx
@@ -1,30 +1,15 @@
-import React, { ChangeEvent, useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import Layout from '../../../common/layout/Layout';
 import { Button } from 'reactstrap';
 import './paymentPage.scss';
-import Input from '../../../common/Input';
-import { getTermsDocumentUrl } from '../../../utils/urls';
 
 interface Props {
-  termsInfo: string;
-  needsConfirmation?: boolean;
   handlePay: () => void;
 }
 
-const PaymentPage = ({ termsInfo, needsConfirmation = true, handlePay }: Props) => {
-  const {
-    t,
-    i18n: { language },
-  } = useTranslation();
-  const [termsAccepted, setTermsAccepted] = useState<boolean>(needsConfirmation ? false : true);
-
-  const handleAcceptTermsChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const target = event.target;
-    setTermsAccepted(target.checked);
-  };
-
-  const termsDocumentUrl = getTermsDocumentUrl(language);
+const PaymentPage = ({ handlePay }: Props) => {
+  const { t } = useTranslation();
 
   return (
     <Layout>
@@ -32,7 +17,7 @@ const PaymentPage = ({ termsInfo, needsConfirmation = true, handlePay }: Props) 
         <div className="vene-payment-page__content-container">
           <div className="vene-payment-page__content">
             <h2>{t('page.payment.title')}</h2>
-            <p>{termsInfo}</p>
+            <p>{t('page.payment.info')}</p>
             <p className="vene-payment-page__contact-info">
               {t('page.payment.questions')}&nbsp;
               <a href="mailto:venepaikkavaraukset@hel.fi" className="vene-payment-page__link">
@@ -43,34 +28,7 @@ const PaymentPage = ({ termsInfo, needsConfirmation = true, handlePay }: Props) 
         </div>
         <div className="vene-payment-page__content-container">
           <div className="vene-payment-page__content vene-payment-page__accept-terms-content">
-            {needsConfirmation && (
-              <>
-                <div>
-                  <a
-                    href={termsDocumentUrl}
-                    className="vene-payment-page__link"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    {t('page.payment.terms_pdf')}
-                  </a>
-                </div>
-                <div>
-                  <Input
-                    type="checkbox"
-                    id="acceptTerms"
-                    label="page.payment.accept_terms"
-                    onChange={handleAcceptTermsChange}
-                  />
-                </div>
-              </>
-            )}
-            <Button
-              className="vene-payment-page__pay-button"
-              color="secondary"
-              disabled={!termsAccepted}
-              onClick={handlePay}
-            >
+            <Button className="vene-payment-page__pay-button" color="secondary" onClick={handlePay}>
               {t('page.payment.pay')}
             </Button>
           </div>

--- a/src/components/pages/paymentPage/PaymentPageContainer.test.tsx
+++ b/src/components/pages/paymentPage/PaymentPageContainer.test.tsx
@@ -27,5 +27,6 @@ describe('PaymentPageContainer', () => {
       );
       expect(wrapper.find(testItem[1] as string).exists()).toBeTruthy();
     });
+    expect.assertions(6);
   });
 });

--- a/src/components/pages/paymentPage/PaymentPageContainer.test.tsx
+++ b/src/components/pages/paymentPage/PaymentPageContainer.test.tsx
@@ -5,31 +5,27 @@ import { getPaymentPage } from './PaymentPageContainer';
 import { OrderStatus, OrderTypeEnum } from '../../../__generated__/globalTypes';
 
 describe('PaymentPageContainer', () => {
-  const t = jest.fn();
   it('should get correct page based on order status', () => {
-    const confirmPayment = jest.fn();
-
-    let wrapper = shallow(getPaymentPage(OrderTypeEnum.BERTH, null, confirmPayment, t));
-    expect(wrapper.find('#vene-payment-general-error-page').exists()).toBeTruthy();
-
-    wrapper = shallow(getPaymentPage(OrderTypeEnum.BERTH, undefined, confirmPayment, t));
-    expect(wrapper.find('#vene-payment-general-error-page').exists()).toBeTruthy();
-
-    wrapper = shallow(getPaymentPage(OrderTypeEnum.BERTH, OrderStatus.WAITING, confirmPayment, t));
-    expect(wrapper.find('#vene-payment-page').exists()).toBeTruthy();
-
-    wrapper = shallow(
-      getPaymentPage(OrderTypeEnum.ADDITIONAL_PRODUCT, OrderStatus.WAITING, confirmPayment, t)
-    );
-    expect(wrapper.find('#vene-payment-page').exists()).toBeTruthy();
-
-    wrapper = shallow(getPaymentPage(OrderTypeEnum.BERTH, OrderStatus.EXPIRED, confirmPayment, t));
-    expect(wrapper.find('#vene-payment-expired-page').exists()).toBeTruthy();
-
-    wrapper = shallow(getPaymentPage(OrderTypeEnum.BERTH, OrderStatus.PAID, confirmPayment, t));
-    expect(wrapper.find('#vene-already-paid-page').exists()).toBeTruthy();
-
-    wrapper = shallow(getPaymentPage(OrderTypeEnum.BERTH, OrderStatus.REJECTED, confirmPayment, t));
-    expect(wrapper.find('#vene-payment-general-error-page').exists()).toBeTruthy();
+    [
+      [null, '#vene-payment-general-error-page'],
+      [undefined, '#vene-payment-general-error-page'],
+      [OrderStatus.WAITING, '#vene-payment-page'],
+      [OrderStatus.EXPIRED, '#vene-payment-expired-page'],
+      [OrderStatus.PAID, '#vene-already-paid-page'],
+      [OrderStatus.REJECTED, '#vene-payment-general-error-page'],
+    ].forEach((testItem) => {
+      const wrapper = shallow(
+        getPaymentPage(
+          OrderTypeEnum.BERTH,
+          '',
+          true,
+          testItem[0] as OrderStatus,
+          [],
+          jest.fn(),
+          jest.fn()
+        )
+      );
+      expect(wrapper.find(testItem[1] as string).exists()).toBeTruthy();
+    });
   });
 });

--- a/src/components/pages/paymentPage/authButton/AuthButton.tsx
+++ b/src/components/pages/paymentPage/authButton/AuthButton.tsx
@@ -11,7 +11,7 @@ interface AuthButtonProps {
 const AuthButton = ({ name, identifier, image, onClick }: AuthButtonProps) => {
   return (
     <div className="vene-payment-page__auth-button__container">
-      <b>{name}</b>
+      <strong>{name}</strong>
       <button onClick={onClick} className="vene-payment-page__auth-button__button">
         <img src={image} alt={identifier} />
       </button>

--- a/src/components/pages/paymentPage/authButton/AuthButton.tsx
+++ b/src/components/pages/paymentPage/authButton/AuthButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import './authButton.scss';
+
+interface AuthButtonProps {
+  name: string;
+  identifier: string;
+  image: string;
+  onClick: () => void;
+}
+
+const AuthButton = ({ name, identifier, image, onClick }: AuthButtonProps) => {
+  return (
+    <div className="vene-payment-page__auth-button__container">
+      <b>{name}</b>
+      <button onClick={onClick} className="vene-payment-page__auth-button__button">
+        <img src={image} alt={identifier} />
+      </button>
+    </div>
+  );
+};
+
+export default AuthButton;

--- a/src/components/pages/paymentPage/authButton/authButton.scss
+++ b/src/components/pages/paymentPage/authButton/authButton.scss
@@ -1,0 +1,10 @@
+.vene-payment-page {
+  &__auth-button {
+    &__container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-self: start;
+    }
+  }
+}

--- a/src/components/pages/paymentPage/paymentPage.scss
+++ b/src/components/pages/paymentPage/paymentPage.scss
@@ -59,4 +59,10 @@
   &__contact-info {
     margin-bottom: 0;
   }
+
+  &__signing-providers {
+    display: grid;
+    grid-template-columns: auto auto;
+    grid-row-gap: $spacing-01;
+  }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -651,14 +651,20 @@
       "paragraph1": "We are sorry, but the payment failed or was cancelled.",
       "paragraph2": "Please try again later, or contact the customer service."
     },
+    "contract": {
+      "title": "Signing the contract and paying the invoice",
+      "info": "Dear customer, we have created for you a contract that is to be signed electronically. See the contract below. You can continue to identify and pay after accepting the terms of the contract. Obtaining a berth or winter storage place requires acceptance of the terms of a contract.",
+      "questions": "Questions and further information: ",
+      "terms_pdf": "Open contract (PDF)",
+      "terms_checkbox": "I have read and accept the contract terms",
+      "terms_form_submit": "Continue to authentication",
+      "select_signing_provider": "Sign the contract by choosing an authentication method"
+    },
     "payment": {
       "title": "Paying the invoice",
-      "terms_info": "Dear customer, we have updated the agreement terms for winter storage spaces. Please read the agreement terms below. You can continue to making your payment after that. Reserving a winter storage space requires that you accept the agreement terms.",
-      "additional_services_terms_info": "Dear customer, here you can pay your additional service bill.",
+      "info": "You can proceed to pay your invoice.",
       "questions": "Questions and further information: ",
-      "terms_pdf": "Winter storage space agreement terms (PDF)",
-      "accept_terms": "I have read and accept the winter storage space agreement terms",
-      "pay": "Continue to making your payment"
+      "pay": "Continue to payment"
     },
     "winter_storage": {
       "appointed": "Appointed spaces",
@@ -802,6 +808,7 @@
       "must_be_number": "The value must be a number",
       "must_be_phone_number": "The value must be a telephone number",
       "must_be_positive_number": "The value must be greater than zero",
+      "must_be_ssn": "Entered value is not a valid SSN",
       "required": "Mandatory field"
     }
   }

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -651,13 +651,19 @@
       "paragraph1": "Pahoittelut. Maksu epäonnistui tai peruutettiin.",
       "paragraph2": "Yritä myöhemmin uudelleen tai ota yhteyttä asiakaspalveluun."
     },
+    "contract": {
+      "title": "Sopimuksen allekirjoittaminen ja laskun maksaminen",
+      "info": "Hyvä asiakkaamme, olemme luoneet teille sopimuksen joka allekirjoitetaan sähköisesti. Tutustu sopimukseen alla. Voit jatkaa tunnistautumiseen ja maksamiseen hyväksyttyäsi sopimusehdot. Vene- tai talvisäilytyspaikan saaminen edellyttää sopimusehtojen hyväksymistä.",
+      "questions": "Kysymykset ja lisätiedot: ",
+      "terms_pdf": "Avaa sopimusehdot (PDF)",
+      "terms_checkbox": "Olen lukenut sopimusehdot ja hyväksyn ne",
+      "terms_form_submit": "Jatka tunnistautumiseen",
+      "select_signing_provider": "Allekirjoita sopimus valitsemalla tunnistautumistapa"
+    },
     "payment": {
       "title": "Laskun maksaminen",
-      "terms_info": "Hyvä asiakkaamme, olemme päivittäneet talvisäilytyspaikan sopimusehtoja. Tutustu sopimusehtojen sisältöön alla. Voit jatkaa maksutapahtumaan sen jälkeen. Talvisäilytyspaikan saaminen edellyttää sopimusehtojen hyväksymistä.",
-      "additional_services_terms_info": "Hyvä asiakkaamme, tästä pääset maksamaan lisäpalvelulaskusi.",
+      "info": "Voit siirtyä maksamaan laskusi.",
       "questions": "Kysymykset ja lisätiedot: ",
-      "terms_pdf": "Talvisäilytyspaikan sopimusehdot (PDF)",
-      "accept_terms": "Olen lukenut talvisäilytyspaikan sopimusehdot ja hyväksyn ne",
       "pay": "Jatka maksamaan"
     },
     "winter_storage": {
@@ -802,6 +808,7 @@
       "must_be_number": "Arvon pitää olla numero",
       "must_be_phone_number": "Arvon pitää olla puhelinnumero",
       "must_be_positive_number": "Arvon pitää olla suurempi kuin nolla",
+      "must_be_ssn": "Syötetty arvo ei ole kelvollinen henkilötunnus",
       "required": "Pakollinen kenttä"
     }
   }

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -651,14 +651,20 @@
       "paragraph1": "Vi beklagar, men betalningen misslyckades eller avbröts.",
       "paragraph2": "Försök igen senare eller kontakta kundtjänsten."
     },
+    "contract": {
+      "title": "Signing the contract and paying the invoice",
+      "info": "Dear customer, we have created for you a contract that is to be signed electronically. See the contract below. You can continue to identify and pay after accepting the terms of the contract. Obtaining a berth or winter storage place requires acceptance of the terms of a contract.",
+      "questions": "Questions and further information: ",
+      "terms_pdf": "Open contract (PDF)",
+      "terms_checkbox": "I have read and accept the contract terms",
+      "terms_form_submit": "Continue to authentication",
+      "select_signing_provider": "Sign the contract by choosing an authentication method"
+    },
     "payment": {
-      "title": "Betalning av faktura",
-      "terms_info": "Bästa kund, vi har uppdaterat avtalsvillkoren för vinteruppläggningsplatser. Läs avtalsvillkoren nedan. Därefter kan du fortsätta med betalningen. För att få en vinteruppläggningsplats måste du godkänna avtalsvillkoren.",
-      "additional_services_terms_info": "Bästa kund, här får du betala din faktura för ytterligare service.",
-      "questions": "Frågor och mer information: ",
-      "terms_pdf": "Avtalsvillkor för vinteruppläggningsplatser (PDF)",
-      "accept_terms": "Jag har läst avtalsvillkoren för vinteruppläggningsplatser och godkänner dem",
-      "pay": "Fortsätt till betalningen"
+      "title": "Paying the invoice",
+      "info": "You can proceed to pay your invoice.",
+      "questions": "Questions and further information: ",
+      "pay": "Continue to payment"
     },
     "winter_storage": {
       "appointed": "Markerade rutor",
@@ -802,6 +808,7 @@
       "must_be_number": "Värdet ska vara en siffra",
       "must_be_phone_number": "Värdet ska vara ett telefonnummer",
       "must_be_positive_number": "Värdet ska vara större än noll",
+      "must_be_ssn": "Det angivna värdet är inte ett giltigt personnummer",
       "required": "Obligatoriskt fält"
     }
   }

--- a/src/utils/__generated__/ContractAuthMethods.ts
+++ b/src/utils/__generated__/ContractAuthMethods.ts
@@ -1,0 +1,19 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: ContractAuthMethods
+// ====================================================
+
+export interface ContractAuthMethods_contractAuthMethods {
+  __typename: "AuthMethod";
+  identifier: string;
+  name: string;
+  image: string;
+}
+
+export interface ContractAuthMethods {
+  contractAuthMethods: ContractAuthMethods_contractAuthMethods[];
+}

--- a/src/utils/__generated__/ContractSigned.ts
+++ b/src/utils/__generated__/ContractSigned.ts
@@ -1,0 +1,21 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: ContractSigned
+// ====================================================
+
+export interface ContractSigned_contractSigned {
+  __typename: "ContractSignedType";
+  isSigned: boolean;
+}
+
+export interface ContractSigned {
+  contractSigned: ContractSigned_contractSigned | null;
+}
+
+export interface ContractSignedVariables {
+  orderNumber: string;
+}

--- a/src/utils/__generated__/FulfillContract.ts
+++ b/src/utils/__generated__/FulfillContract.ts
@@ -1,0 +1,23 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { FulfillContractMutationInput } from "./../../__generated__/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: FulfillContract
+// ====================================================
+
+export interface FulfillContract_fulfillContract {
+  __typename: "FulfillContractMutationPayload";
+  signingUrl: string | null;
+}
+
+export interface FulfillContract {
+  fulfillContract: FulfillContract_fulfillContract | null;
+}
+
+export interface FulfillContractVariables {
+  fulfillContractMutationInput: FulfillContractMutationInput;
+}

--- a/src/utils/__generated__/OrderDetails.ts
+++ b/src/utils/__generated__/OrderDetails.ts
@@ -15,8 +15,22 @@ export interface OrderDetails_orderDetails {
   status: OrderStatus;
 }
 
+export interface OrderDetails_contractSigned {
+  __typename: "ContractSignedType";
+  isSigned: boolean | null;
+}
+
+export interface OrderDetails_contractAuthMethods {
+  __typename: "AuthMethod";
+  identifier: string;
+  name: string;
+  image: string;
+}
+
 export interface OrderDetails {
   orderDetails: OrderDetails_orderDetails | null;
+  contractSigned: OrderDetails_contractSigned | null;
+  contractAuthMethods: OrderDetails_contractAuthMethods[];
 }
 
 export interface OrderDetailsVariables {

--- a/src/utils/formValidation.test.ts
+++ b/src/utils/formValidation.test.ts
@@ -81,6 +81,7 @@ describe('formValidation', () => {
         '-033A',
         'A',
       ].forEach((value) => expect(mustBeSsn(value)).toEqual('validation.message.must_be_ssn'));
+      expect.assertions(8);
     });
   });
 });

--- a/src/utils/formValidation.test.ts
+++ b/src/utils/formValidation.test.ts
@@ -1,4 +1,4 @@
-import validator, { mustBeEmail, mustNotExceedTwoDecimals } from './formValidation';
+import validator, { mustBeEmail, mustBeSsn, mustNotExceedTwoDecimals } from './formValidation';
 
 describe('formValidation', () => {
   describe('mustNotExceedTwoDecimals', () => {
@@ -58,6 +58,29 @@ describe('formValidation', () => {
       const withErrFn2 = jest.fn().mockReturnValue(err2);
 
       expect(validator(withErrFn1, withErrFn2)('foo')).toBe(err1);
+    });
+  });
+
+  describe('mustBeSsn', () => {
+    test('should return true for valid ssn', () => {
+      expect(mustBeSsn('020175-033H')).toBeUndefined();
+    });
+
+    test('should return false if verification character is incorrect', () => {
+      expect(mustBeSsn('020175-033A')).toEqual('validation.message.must_be_ssn');
+    });
+
+    test('should return false for malformed ssn', () => {
+      [
+        '020175033H',
+        '02017-033H',
+        '020175-03H',
+        '020175K033H',
+        '',
+        '020175',
+        '-033A',
+        'A',
+      ].forEach((value) => expect(mustBeSsn(value)).toEqual('validation.message.must_be_ssn'));
     });
   });
 });

--- a/src/utils/formValidation.ts
+++ b/src/utils/formValidation.ts
@@ -59,3 +59,58 @@ export default <T>(...fns: (((...args: any[]) => T | undefined) | null)[]) => (
 
   return validated;
 };
+
+const ssnValidationTable = [
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  'A',
+  'B',
+  'C',
+  'D',
+  'E',
+  'F',
+  'H',
+  'J',
+  'K',
+  'L',
+  'M',
+  'N',
+  'P',
+  'R',
+  'S',
+  'T',
+  'U',
+  'V',
+  'W',
+  'X',
+  'Y',
+];
+
+const validateSsn = (number: number, checkCharacter: string) => {
+  return checkCharacter === ssnValidationTable[number % 31];
+};
+
+export const mustBeSsn = (value: string) => {
+  const ssnRe = /^([0-9]{6})([\\+\-A])([0-9]{3})([0-9A-FHJ-NPR-Y])$/;
+  if (!ssnRe.test(value)) {
+    return 'validation.message.must_be_ssn';
+  }
+
+  const groups = value.match(ssnRe) ?? [];
+  const number = parseInt(`${groups[1]}${groups[3]}`, 10);
+  const checkCharacter = groups[4];
+
+  if (!validateSsn(number, checkCharacter)) {
+    return 'validation.message.must_be_ssn';
+  }
+
+  return undefined;
+};

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -149,19 +149,35 @@ export const GET_HARBOR_NAME = (harborId: string) => gql`
   }
 `;
 
+export const CONFIRM_PAYMENT = gql`
+  mutation ConfirmPayment($confirmPaymentMutationInput: ConfirmPaymentMutationInput!) {
+    confirmPayment(input: $confirmPaymentMutationInput) {
+      url
+    }
+  }
+`;
+
+export const FULFILL_CONTRACT = gql`
+  mutation FulfillContract($fulfillContractMutationInput: FulfillContractMutationInput!) {
+    fulfillContract(input: $fulfillContractMutationInput) {
+      signingUrl
+    }
+  }
+`;
+
 export const GET_ORDER_DETAILS = gql`
   query OrderDetails($orderNumber: String!) {
     orderDetails(orderNumber: $orderNumber) {
       orderType
       status
     }
-  }
-`;
-
-export const CONFIRM_PAYMENT = gql`
-  mutation ConfirmPayment($confirmPaymentMutationInput: ConfirmPaymentMutationInput!) {
-    confirmPayment(input: $confirmPaymentMutationInput) {
-      url
+    contractSigned(orderNumber: $orderNumber) {
+      isSigned
+    }
+    contractAuthMethods {
+      identifier
+      name
+      image
     }
   }
 `;

--- a/src/utils/urls.test.ts
+++ b/src/utils/urls.test.ts
@@ -1,14 +1,13 @@
-import { getOrderNumber, getPaymentSuccess, getTermsDocumentUrl } from './urls';
+import { getOrderNumber, getPaymentSuccess } from './urls';
 
 describe('utils/urls', () => {
   describe('getOrderNumber', () => {
     it('should get order number', () => {
       expect(getOrderNumber('?order_number=123')).toEqual('123');
-
-      expect(getOrderNumber('?order_number=')).toEqual(null);
-      expect(getOrderNumber('?order_number=123&order_number=123')).toEqual(null);
-      expect(getOrderNumber('?foo=123')).toEqual(null);
-      expect(getOrderNumber('')).toEqual(null);
+      expect(getOrderNumber('?order_number=')).toEqual('');
+      expect(getOrderNumber('?order_number=123&order_number=123')).toEqual('');
+      expect(getOrderNumber('?foo=123')).toEqual('');
+      expect(getOrderNumber('')).toEqual('');
     });
 
     it('should get payment success', () => {
@@ -16,12 +15,6 @@ describe('utils/urls', () => {
       expect(getPaymentSuccess('?payment_status=failure')).toBeFalsy();
       expect(getPaymentSuccess('?payment_status=')).toBeFalsy();
       expect(getPaymentSuccess('?foo=bar')).toBeFalsy();
-    });
-
-    it('should get terms document URL', () => {
-      expect(getTermsDocumentUrl('fi')).toEqual(
-        '/Helsingin_talvisäilytyspaikan_vuokrasopimusehdot-fi.pdf'
-      );
     });
   });
 });

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,11 +1,11 @@
 import queryString from 'query-string';
 
-export const getOrderNumber = (searchString: string): string | null => {
+export const getOrderNumber = (searchString: string): string => {
   const parsed = queryString.parse(searchString);
   const orderNumber = parsed.order_number;
 
   if (Array.isArray(orderNumber) || !orderNumber) {
-    return null;
+    return '';
   }
   return orderNumber;
 };
@@ -14,8 +14,4 @@ export const getPaymentSuccess = (searchString: string): boolean => {
   const parsed = queryString.parse(searchString);
   const paymentStatus = parsed.payment_status;
   return paymentStatus === 'success';
-};
-
-export const getTermsDocumentUrl = (language: string): string => {
-  return `/Helsingin_talvisäilytyspaikan_vuokrasopimusehdot-${language}.pdf`;
 };


### PR DESCRIPTION
## Description :sparkles:

Adds contract signing step to payments:

- `PaymentPageContainer` fetches order's contract signed status
  - If `null` there's no contract information for the order and proceed directly to payments (additional products case)
  - If `false` show the new contract signing page
  - If `true`, the contract is already signed and display the payment page

### Closes :no_good_woman:

[VEN-976](https://helsinkisolutionoffice.atlassian.net/browse/VEN-976)

## Testing :alembic:

### Automated tests :gear:️

Updated relevant tests, added tests for ssn validator.

### Manual testing :construction_worker_man:

- Handle an application in the admin UI
- Use the generated order number to navigate to `url-to-customer-ui/fi/payment?order_number=...`
- Should display the new contract signing page
- After authentication should redirect to payments page

## Additional notes :spiral_notepad:

The ssn field has been removed from the current implementation as we received information that it's actually optional, even though it has been documented as required in the API docs. We might need to reintroduce it later if some of the authentication methods actually require it.
