### PR TITLE
VEN-1013 | Correct customer service email address

### DIFF
--- a/src/components/pages/paymentPage/PaymentPage.tsx
+++ b/src/components/pages/paymentPage/PaymentPage.tsx
@@ -35,8 +35,8 @@ const PaymentPage = ({ termsInfo, needsConfirmation = true, handlePay }: Props) 
             <p>{termsInfo}</p>
             <p className="vene-payment-page__contact-info">
               {t('page.payment.questions')}&nbsp;
-              <a href="mailto:venepaikat@hel.fi" className="vene-payment-page__link">
-                venepaikat@hel.fi
+              <a href="mailto:venepaikkavaraukset@hel.fi" className="vene-payment-page__link">
+                venepaikkavaraukset@hel.fi
               </a>
             </p>
           </div>


### PR DESCRIPTION
## Description :sparkles:

* Correct customer service email address

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1013](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1013): Wrong boat office customer service email-address when customer goes to customer UI from the payment information email link
