### PR TITLE
VEN-1067 | Validate form fields

### DIFF
--- a/src/components/forms/fragments/CompanyDetails.tsx
+++ b/src/components/forms/fragments/CompanyDetails.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import { Col, Row } from 'reactstrap';
+import { mustBeBusinessId, mustBeCompanyName } from '../../../utils/formValidation';
 
 import { Text } from '../Fields';
 
@@ -12,6 +13,7 @@ const CompanyDetailsFragment = () => (
           label="form.company_details.field.name.label"
           placeholder="form.company_details.field.name.placeholder"
           required
+          validate={mustBeCompanyName}
         />
       </Col>
     </Row>
@@ -22,6 +24,7 @@ const CompanyDetailsFragment = () => (
           label="form.company_details.field.business_id.label"
           placeholder="form.company_details.field.business_id.placeholder"
           required
+          validate={mustBeBusinessId}
         />
       </Col>
     </Row>

--- a/src/components/forms/fragments/FullName.tsx
+++ b/src/components/forms/fragments/FullName.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Col, Row } from 'reactstrap';
+import { mustBeNames } from '../../../utils/formValidation';
 
 import { Text } from '../Fields';
 
@@ -11,6 +12,7 @@ const FullNameFragment = () => (
         label="form.private_person.field.first_name.label"
         placeholder="form.private_person.field.first_name.placeholder"
         required
+        validate={mustBeNames(4)}
       />
     </Col>
     <Col sm={4}>
@@ -19,6 +21,7 @@ const FullNameFragment = () => (
         label="form.private_person.field.last_name.label"
         placeholder="form.private_person.field.last_name.placeholder"
         required
+        validate={mustBeNames(1)}
       />
     </Col>
   </Row>

--- a/src/components/forms/fragments/PostalDetails.tsx
+++ b/src/components/forms/fragments/PostalDetails.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Col, Row } from 'reactstrap';
+import { mustBeAddress, mustBePostalCode } from '../../../utils/formValidation';
 
 import { Select, Text } from '../Fields';
 import { MUNICIPALITIES, PRIORITIZED_MUNICIPALITIES } from '../../../constants/Municipalities';
@@ -28,6 +29,7 @@ const PostalDetailsFragment = () => {
           label={`form.postal_details.field.street_address.label`}
           placeholder={`form.postal_details.field.street_address.placeholder`}
           required
+          validate={mustBeAddress}
         />
       </Col>
       <Col sm={4}>
@@ -36,6 +38,7 @@ const PostalDetailsFragment = () => {
           label={`form.postal_details.field.postal_code.label`}
           placeholder={`form.postal_details.field.postal_code.placeholder`}
           required
+          validate={mustBePostalCode}
         />
       </Col>
       <Col sm={4}>

--- a/src/components/forms/fragments/RegisteredBoatDetails.tsx
+++ b/src/components/forms/fragments/RegisteredBoatDetails.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Col, Row } from 'reactstrap';
+import { mustBeBoatRegistrationNumber } from '../../../utils/formValidation';
 
 import { Text } from '../Fields';
 import { BoatType, WithBoatType } from '../Selects';
@@ -19,6 +20,7 @@ const RegisteredBoatDetailsFragment = ({ boatTypes }: WithBoatType) => {
             label="form.registered.field.register_number.label"
             placeholder="form.registered.field.register_number.placeholder"
             required
+            validate={mustBeBoatRegistrationNumber}
           />
         </Col>
         <Col sm={6}>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -383,7 +383,7 @@
           "field": {
             "label": "Trailerin rekisterinumero",
             "placeholder": "ABC-123",
-            "text": "Trailerilla säilytys vain rekisteröidylle trailereille. Jos trailerin rekisterinumero ei ole vielä tiedossa, ilmoita rekisterinumero ennen talvisäilytyksen aloittamista. Trailerilla säilyttäminen vaatii veneen pituuden lisäksi 1m lisätilaa."
+            "text": "Trailerilla säilytys vain rekisteröidyille trailereille. Jos trailerin rekisterinumero ei ole vielä tiedossa, ilmoita rekisterinumero ennen talvisäilytyksen aloittamista. Trailerilla säilyttäminen vaatii veneen pituuden lisäksi 1m lisätilaa."
           }
         }
       }

--- a/src/utils/formValidation.test.ts
+++ b/src/utils/formValidation.test.ts
@@ -1,6 +1,36 @@
-import validator, { mustBeEmail, mustBeSsn, mustNotExceedTwoDecimals } from './formValidation';
+import validator, {
+  mustBeEmail,
+  mustBeNames,
+  mustBeSsn,
+  mustNotExceedTwoDecimals,
+} from './formValidation';
 
 describe('formValidation', () => {
+  describe('mustBeNames', () => {
+    test('should return undefined if name count is ok and names are valid', () => {
+      expect(mustBeNames(1)('Aki')).toBeUndefined();
+      expect(mustBeNames(3)('Aki')).toBeUndefined();
+      expect(mustBeNames(3)('Jukka-Pekka Matti Antero')).toBeUndefined();
+      expect(mustBeNames(3)('Øyvind Pär Ánton')).toBeUndefined();
+    });
+    test('should return an error message if there is no name', () => {
+      expect(mustBeNames(1)('')).toEqual('validation.message.invalid_value');
+      expect(mustBeNames(1)(' ')).toEqual('validation.message.invalid_value');
+    });
+    test('should return an error message if name count is over maxNames', () => {
+      expect(mustBeNames(2)('Jukka Pekka Antero')).toEqual('validation.message.invalid_value');
+    });
+    test('should return an error message if there is extra whitespace', () => {
+      expect(mustBeNames(2)(' Jukka Pekka')).toEqual('validation.message.invalid_value');
+      expect(mustBeNames(2)('Jukka Pekka ')).toEqual('validation.message.invalid_value');
+    });
+    test('should return an error message if the names are invalid', () => {
+      expect(mustBeNames(2)('Ville%')).toEqual('validation.message.invalid_value');
+      expect(mustBeNames(2)('😀')).toEqual('validation.message.invalid_value');
+      expect(mustBeNames(2)('寅泰')).toEqual('validation.message.invalid_value');
+    });
+  });
+
   describe('mustNotExceedTwoDecimals', () => {
     test('should return undefined if the value has no more than two decimals', () => {
       expect(mustNotExceedTwoDecimals('1000.00')).toBeUndefined();

--- a/src/utils/formValidation.test.ts
+++ b/src/utils/formValidation.test.ts
@@ -6,6 +6,7 @@ import validator, {
   mustBeEmail,
   mustBeNames,
   mustBePostalCode,
+  mustBePresent,
   mustBeSsn,
   mustNotExceedTwoDecimals,
   stringHasNoExtraWhitespace,
@@ -21,6 +22,18 @@ describe('formValidation', () => {
     });
     test('should return false on string with trailing whitespace', () => {
       expect(stringHasNoExtraWhitespace('Test ')).toBe(false);
+    });
+  });
+
+  describe('mustBePresent', () => {
+    test('should return undefined if value exists', () => {
+      expect(mustBePresent('Test')).toBeUndefined();
+    });
+    test('should return an error message if value is undefined', () => {
+      expect(mustBePresent(undefined)).toEqual('validation.message.required');
+    });
+    test('should return an error message if value is only spaces', () => {
+      expect(mustBePresent(' ')).toEqual('validation.message.required');
     });
   });
 

--- a/src/utils/formValidation.test.ts
+++ b/src/utils/formValidation.test.ts
@@ -1,5 +1,6 @@
 import validator, {
   mustBeAddress,
+  mustBeBoatRegistrationNumber,
   mustBeBusinessId,
   mustBeCompanyName,
   mustBeEmail,
@@ -161,6 +162,19 @@ describe('formValidation', () => {
       expect(mustBeBusinessId('12345678')).toEqual('validation.message.invalid_value');
       expect(mustBeBusinessId('12345678-')).toEqual('validation.message.invalid_value');
       expect(mustBeBusinessId('Abc')).toEqual('validation.message.invalid_value');
+    });
+  });
+
+  describe('mustBeBoatRegistrationNumber', () => {
+    test('should return undefined if number is valid', () => {
+      expect(mustBeBoatRegistrationNumber('A1')).toBeUndefined();
+      expect(mustBeBoatRegistrationNumber('Z1234567')).toBeUndefined();
+      expect(mustBeBoatRegistrationNumber('P12345')).toBeUndefined();
+    });
+    test('should return an error message if number is invalid', () => {
+      expect(mustBeBoatRegistrationNumber('P1')).toEqual('validation.message.invalid_value');
+      expect(mustBeBoatRegistrationNumber('A12345678')).toEqual('validation.message.invalid_value');
+      expect(mustBeBoatRegistrationNumber('A-1')).toEqual('validation.message.invalid_value');
     });
   });
 });

--- a/src/utils/formValidation.test.ts
+++ b/src/utils/formValidation.test.ts
@@ -1,8 +1,10 @@
 import validator, {
+  mustBeAddress,
   mustBeBusinessId,
   mustBeCompanyName,
   mustBeEmail,
   mustBeNames,
+  mustBePostalCode,
   mustBeSsn,
   mustNotExceedTwoDecimals,
 } from './formValidation';
@@ -42,6 +44,28 @@ describe('formValidation', () => {
       expect(mustBeCompanyName('Abc% Oy')).toEqual('validation.message.invalid_value');
       expect(mustBeCompanyName('😀 Oy')).toEqual('validation.message.invalid_value');
       expect(mustBeCompanyName('寅泰')).toEqual('validation.message.invalid_value');
+    });
+  });
+
+  describe('mustBeAddress', () => {
+    test('should return undefined if address is valid', () => {
+      expect(mustBeAddress('Testikatu 1')).toBeUndefined();
+      expect(mustBeAddress('Testitie 1 as. 1, c/o Matti Meikäläinen (lisätieto)')).toBeUndefined();
+    });
+    test('should return an error message if address has invalid characters', () => {
+      expect(mustBeAddress('Testikatu #1')).toEqual('validation.message.invalid_value');
+      expect(mustBeAddress('Testikatu 1😀')).toEqual('validation.message.invalid_value');
+    });
+  });
+
+  describe('mustBePostalCode', () => {
+    test('should return undefined if postal code is valid', () => {
+      expect(mustBePostalCode('00100')).toBeUndefined();
+    });
+    test('should return an error message if postal code has invalid characters or length', () => {
+      expect(mustBePostalCode('A00100')).toEqual('validation.message.invalid_value');
+      expect(mustBePostalCode('0100')).toEqual('validation.message.invalid_value');
+      expect(mustBePostalCode('000100')).toEqual('validation.message.invalid_value');
     });
   });
 

--- a/src/utils/formValidation.test.ts
+++ b/src/utils/formValidation.test.ts
@@ -1,4 +1,6 @@
 import validator, {
+  mustBeBusinessId,
+  mustBeCompanyName,
   mustBeEmail,
   mustBeNames,
   mustBeSsn,
@@ -28,6 +30,18 @@ describe('formValidation', () => {
       expect(mustBeNames(2)('Ville%')).toEqual('validation.message.invalid_value');
       expect(mustBeNames(2)('😀')).toEqual('validation.message.invalid_value');
       expect(mustBeNames(2)('寅泰')).toEqual('validation.message.invalid_value');
+    });
+  });
+
+  describe('mustBeCompanyName', () => {
+    test('should return undefined if name is valid', () => {
+      expect(mustBeCompanyName('Abc Oy')).toBeUndefined();
+      expect(mustBeCompanyName('Abc')).toBeUndefined();
+    });
+    test('should return an error message if the name has invalid characters', () => {
+      expect(mustBeCompanyName('Abc% Oy')).toEqual('validation.message.invalid_value');
+      expect(mustBeCompanyName('😀 Oy')).toEqual('validation.message.invalid_value');
+      expect(mustBeCompanyName('寅泰')).toEqual('validation.message.invalid_value');
     });
   });
 
@@ -112,6 +126,17 @@ describe('formValidation', () => {
         'A',
       ].forEach((value) => expect(mustBeSsn(value)).toEqual('validation.message.must_be_ssn'));
       expect.assertions(8);
+    });
+  });
+
+  describe('mustBeBusinessId', () => {
+    test('should return undefined if businessId is valid', () => {
+      expect(mustBeBusinessId('1234567-8')).toBeUndefined();
+    });
+    test('should return an error message if businessId is invalid', () => {
+      expect(mustBeBusinessId('12345678')).toEqual('validation.message.invalid_value');
+      expect(mustBeBusinessId('12345678-')).toEqual('validation.message.invalid_value');
+      expect(mustBeBusinessId('Abc')).toEqual('validation.message.invalid_value');
     });
   });
 });

--- a/src/utils/formValidation.test.ts
+++ b/src/utils/formValidation.test.ts
@@ -8,9 +8,22 @@ import validator, {
   mustBePostalCode,
   mustBeSsn,
   mustNotExceedTwoDecimals,
+  stringHasNoExtraWhitespace,
 } from './formValidation';
 
 describe('formValidation', () => {
+  describe('stringHasNoExtraWhitespace', () => {
+    test('should return true on string without leading or trailing whitespace', () => {
+      expect(stringHasNoExtraWhitespace('Test')).toBe(true);
+    });
+    test('should return false on string with leading whitespace', () => {
+      expect(stringHasNoExtraWhitespace(' Test')).toBe(false);
+    });
+    test('should return false on string with trailing whitespace', () => {
+      expect(stringHasNoExtraWhitespace('Test ')).toBe(false);
+    });
+  });
+
   describe('mustBeNames', () => {
     test('should return undefined if name count is ok and names are valid', () => {
       expect(mustBeNames(1)('Aki')).toBeUndefined();

--- a/src/utils/formValidation.ts
+++ b/src/utils/formValidation.ts
@@ -156,3 +156,11 @@ export const mustBeBusinessId = (value: any): string | undefined => {
   }
   return 'validation.message.invalid_value';
 };
+
+export const mustBeBoatRegistrationNumber = (value: any): string | undefined => {
+  const regex = /^([PEL][0-9]{5,10})|([A-DF-KOQ-Z][0-9]{1,7})$/;
+  if (regex.test(value)) {
+    return undefined;
+  }
+  return 'validation.message.invalid_value';
+};

--- a/src/utils/formValidation.ts
+++ b/src/utils/formValidation.ts
@@ -1,4 +1,4 @@
-export const stringHasNoExtraWhitespace = (value: string) =>
+export const stringHasNoExtraWhitespace = (value: string): boolean =>
   value.charAt(0) !== ' ' && value.charAt(value.length - 1) !== ' ';
 
 export const mustBePresent = (value: any): string | undefined => {
@@ -16,7 +16,7 @@ export const mustBeNames = (maxNames: number) => (value: any): string | undefine
   return 'validation.message.invalid_value';
 };
 
-export const mustBeCompanyName = (value: any): string | undefined => {
+export const mustBeCompanyName = (value: string): string | undefined => {
   const regex = /^([a-zA-ZåäöÅÄÖ0-9- ]+)$/;
   if (regex.test(value) && stringHasNoExtraWhitespace(value)) {
     return undefined;
@@ -24,7 +24,7 @@ export const mustBeCompanyName = (value: any): string | undefined => {
   return 'validation.message.invalid_value';
 };
 
-export const mustBeAddress = (value: any): string | undefined => {
+export const mustBeAddress = (value: string): string | undefined => {
   const regex = /^([a-zA-ZåäöÅÄÖ0-9-/.,() ]+)$/;
   if (regex.test(value) && stringHasNoExtraWhitespace(value)) {
     return undefined;
@@ -32,7 +32,7 @@ export const mustBeAddress = (value: any): string | undefined => {
   return 'validation.message.invalid_value';
 };
 
-export const mustBePostalCode = (value: any): string | undefined => {
+export const mustBePostalCode = (value: string): string | undefined => {
   const regex = /^([0-9]{5})$/;
   if (regex.test(value)) {
     return undefined;
@@ -40,14 +40,14 @@ export const mustBePostalCode = (value: any): string | undefined => {
   return 'validation.message.invalid_value';
 };
 
-export const mustBeNumber = (value: any): string | undefined =>
-  isNaN(value) ? 'validation.message.must_be_number' : undefined;
+export const mustBeNumber = (value: string): string | undefined =>
+  isNaN(parseFloat(value)) ? 'validation.message.must_be_number' : undefined;
 
-export const mustBePositiveNumber = (value: number): string | undefined => {
-  if (isNaN(value)) {
+export const mustBePositiveNumber = (value: string): string | undefined => {
+  if (isNaN(parseFloat(value))) {
     return 'validation.message.must_be_number';
   }
-  if (value < 0) {
+  if (parseFloat(value) < 0) {
     return 'validation.message.must_be_positive_number';
   }
 
@@ -63,7 +63,7 @@ export const mustNotExceedTwoDecimals = (value: string): string | undefined => {
 };
 
 export const mustBeLessThan = (limit: number) => (value: string): string | undefined => {
-  if (Number(value) >= limit) {
+  if (parseFloat(value) >= limit) {
     return 'validation.message.must_be_less';
   }
   return undefined;
@@ -77,15 +77,15 @@ export const mustBePhoneNumber = (value: string): string | undefined => {
   return 'validation.message.must_be_phone_number';
 };
 
-export const mustBeEmail = (value: any): any => {
+export const mustBeEmail = (value: string): string | undefined => {
   const emailRe = /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
-  if (typeof value === 'string' && emailRe.test(value.toLowerCase())) {
+  if (emailRe.test(value.toLowerCase())) {
     return undefined;
   }
   return 'validation.message.must_be_email';
 };
 
-export default <T>(...fns: (((...args: any[]) => T | undefined) | null)[]) => (
+export default <T>(...fns: (((...args: string[]) => T | undefined) | null)[]) => (
   value: string
 ): T | undefined => {
   let validated: T | undefined;
@@ -133,11 +133,11 @@ const ssnValidationTable = [
   'Y',
 ];
 
-const validateSsn = (number: number, checkCharacter: string) => {
+const validateSsn = (number: number, checkCharacter: string): boolean => {
   return checkCharacter === ssnValidationTable[number % 31];
 };
 
-export const mustBeSsn = (value: string) => {
+export const mustBeSsn = (value: string): string | undefined => {
   const ssnRe = /^([0-9]{6})([\\+\-A])([0-9]{3})([0-9A-FHJ-NPR-Y])$/;
   if (!ssnRe.test(value)) {
     return 'validation.message.must_be_ssn';
@@ -154,7 +154,7 @@ export const mustBeSsn = (value: string) => {
   return undefined;
 };
 
-export const mustBeBusinessId = (value: any): string | undefined => {
+export const mustBeBusinessId = (value: string): string | undefined => {
   const regex = /^[0-9]{7}-[0-9]$/;
   if (regex.test(value)) {
     return undefined;
@@ -162,7 +162,7 @@ export const mustBeBusinessId = (value: any): string | undefined => {
   return 'validation.message.invalid_value';
 };
 
-export const mustBeBoatRegistrationNumber = (value: any): string | undefined => {
+export const mustBeBoatRegistrationNumber = (value: string): string | undefined => {
   const regex = /^([PEL][0-9]{5,10})|([A-DF-KOQ-Z][0-9]{1,7})$/;
   if (regex.test(value)) {
     return undefined;

--- a/src/utils/formValidation.ts
+++ b/src/utils/formValidation.ts
@@ -1,6 +1,16 @@
 export const mustBePresent = (value: any): string | undefined =>
   value ? undefined : 'validation.message.required';
 
+export const mustBeNames = (maxNames: number) => (value: any): string | undefined => {
+  const regexString = `^(?! )([\\p{Script_Extensions=Latin}-]+\\s*){1,${maxNames}}(?<! )$`;
+  const regex = RegExp(regexString, 'u');
+
+  if (regex.test(value)) {
+    return undefined;
+  }
+  return 'validation.message.invalid_value';
+};
+
 export const mustBeNumber = (value: any): string | undefined =>
   isNaN(value) ? 'validation.message.must_be_number' : undefined;
 

--- a/src/utils/formValidation.ts
+++ b/src/utils/formValidation.ts
@@ -1,8 +1,10 @@
 export const stringHasNoExtraWhitespace = (value: string) =>
   value.charAt(0) !== ' ' && value.charAt(value.length - 1) !== ' ';
 
-export const mustBePresent = (value: any): string | undefined =>
-  value ? undefined : 'validation.message.required';
+export const mustBePresent = (value: any): string | undefined => {
+  if (value && value.trim().length > 0) return undefined;
+  return 'validation.message.required';
+};
 
 export const mustBeNames = (maxNames: number) => (value: any): string | undefined => {
   const regexString = `^([\\p{Script_Extensions=Latin}-]+\\s*){1,${maxNames}}$`;

--- a/src/utils/formValidation.ts
+++ b/src/utils/formValidation.ts
@@ -1,27 +1,30 @@
+export const stringHasNoExtraWhitespace = (value: string) =>
+  value.charAt(0) !== ' ' && value.charAt(value.length - 1) !== ' ';
+
 export const mustBePresent = (value: any): string | undefined =>
   value ? undefined : 'validation.message.required';
 
 export const mustBeNames = (maxNames: number) => (value: any): string | undefined => {
-  const regexString = `^(?! )([\\p{Script_Extensions=Latin}-]+\\s*){1,${maxNames}}(?<! )$`;
+  const regexString = `^([\\p{Script_Extensions=Latin}-]+\\s*){1,${maxNames}}$`;
   const regex = RegExp(regexString, 'u');
 
-  if (regex.test(value)) {
+  if (regex.test(value) && stringHasNoExtraWhitespace(value)) {
     return undefined;
   }
   return 'validation.message.invalid_value';
 };
 
 export const mustBeCompanyName = (value: any): string | undefined => {
-  const regex = /^(?! )([a-zA-ZåäöÅÄÖ0-9- ]+)(?<! )$/;
-  if (regex.test(value)) {
+  const regex = /^([a-zA-ZåäöÅÄÖ0-9- ]+)$/;
+  if (regex.test(value) && stringHasNoExtraWhitespace(value)) {
     return undefined;
   }
   return 'validation.message.invalid_value';
 };
 
 export const mustBeAddress = (value: any): string | undefined => {
-  const regex = /^(?! )([a-zA-ZåäöÅÄÖ0-9-/.,() ]+)(?<! )$/;
-  if (regex.test(value)) {
+  const regex = /^([a-zA-ZåäöÅÄÖ0-9-/.,() ]+)$/;
+  if (regex.test(value) && stringHasNoExtraWhitespace(value)) {
     return undefined;
   }
   return 'validation.message.invalid_value';

--- a/src/utils/formValidation.ts
+++ b/src/utils/formValidation.ts
@@ -19,6 +19,22 @@ export const mustBeCompanyName = (value: any): string | undefined => {
   return 'validation.message.invalid_value';
 };
 
+export const mustBeAddress = (value: any): string | undefined => {
+  const regex = /^(?! )([a-zA-ZåäöÅÄÖ0-9-/.,() ]+)(?<! )$/;
+  if (regex.test(value)) {
+    return undefined;
+  }
+  return 'validation.message.invalid_value';
+};
+
+export const mustBePostalCode = (value: any): string | undefined => {
+  const regex = /^([0-9]{5})$/;
+  if (regex.test(value)) {
+    return undefined;
+  }
+  return 'validation.message.invalid_value';
+};
+
 export const mustBeNumber = (value: any): string | undefined =>
   isNaN(value) ? 'validation.message.must_be_number' : undefined;
 

--- a/src/utils/formValidation.ts
+++ b/src/utils/formValidation.ts
@@ -11,6 +11,14 @@ export const mustBeNames = (maxNames: number) => (value: any): string | undefine
   return 'validation.message.invalid_value';
 };
 
+export const mustBeCompanyName = (value: any): string | undefined => {
+  const regex = /^(?! )([a-zA-ZåäöÅÄÖ0-9- ]+)(?<! )$/;
+  if (regex.test(value)) {
+    return undefined;
+  }
+  return 'validation.message.invalid_value';
+};
+
 export const mustBeNumber = (value: any): string | undefined =>
   isNaN(value) ? 'validation.message.must_be_number' : undefined;
 
@@ -123,4 +131,12 @@ export const mustBeSsn = (value: string) => {
   }
 
   return undefined;
+};
+
+export const mustBeBusinessId = (value: any): string | undefined => {
+  const regex = /^[0-9]{7}-[0-9]$/;
+  if (regex.test(value)) {
+    return undefined;
+  }
+  return 'validation.message.invalid_value';
 };


### PR DESCRIPTION
## Description :sparkles:

* Validate first name, last name, company name, business id, address, postal code and boat registration number fields
* Fix minor typo in trailer registration

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1067](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1067): Customer UI form values should be validated

## Testing :alembic:

### Automated tests :gear:️

* Added tests for new validations

### Manual testing :construction_worker_man:

* Go nuts with the field values. All fields (except boat name, model and trailer registration number) should be validated