### PR TITLE
VEN-1055 | Move error above loading in payment page display priority

### DIFF
--- a/src/components/pages/paymentPage/PaymentPageContainer.tsx
+++ b/src/components/pages/paymentPage/PaymentPageContainer.tsx
@@ -74,6 +74,9 @@ const PaymentPageContainer = () => {
     });
   };
 
+  if (confirmError || orderDetailsError) {
+    return <GeneralPaymentErrorPage />;
+  }
   if (
     loadingOrderDetails ||
     loadingConfirmPayment ||
@@ -81,9 +84,6 @@ const PaymentPageContainer = () => {
     !orderDetailsData?.contractSigned
   ) {
     return <LoadingPage />;
-  }
-  if (confirmError || orderDetailsError) {
-    return <GeneralPaymentErrorPage />;
   }
 
   return getPaymentPage(


### PR DESCRIPTION
## Description :sparkles:

* Move error above loading in payment page display priority

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1055](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1055): If invalid order_number given as parameter to /payment, no error is shown

## Testing :alembic:

### Manual testing :construction_worker_man:

* Open http://localhost:3000/fi/payment?order_number=qwerty and expect to see an error
