### PR TITLE
VEN-1088 | Add info text in payment page before terms link

### DIFF
--- a/src/components/pages/paymentPage/ContractPage.tsx
+++ b/src/components/pages/paymentPage/ContractPage.tsx
@@ -38,6 +38,7 @@ const PaymentPage = ({ contractAuthMethods, orderNumber, handleSign, handleTermi
         <div className="vene-payment-page__content-container">
           <div className="vene-payment-page__content vene-payment-page__accept-terms-content">
             <div>
+              <p className="vene-payment-page__notice">{t('page.contract.terms_notice')}</p>
               <a
                 href={`${process.env.REACT_APP_API_URL_ROOT}contract_document/${orderNumber}`}
                 className="vene-payment-page__link"

--- a/src/components/pages/paymentPage/paymentPage.scss
+++ b/src/components/pages/paymentPage/paymentPage.scss
@@ -1,5 +1,6 @@
 @import 'styles/mixin';
 @import 'helsinki/colors';
+@import 'helsinki/fonts';
 @import 'styles/variables';
 
 .vene-payment-page {
@@ -38,6 +39,10 @@
     > * {
       margin-bottom: $spacing-03;
     }
+  }
+
+  &__notice {
+    font-size: $font-size-sm;
   }
 
   &__link {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -667,6 +667,7 @@
       "info": "Dear customer, we have created for you a contract that is to be signed electronically. See the contract below. You can continue to identify and pay after accepting the terms of the contract. Obtaining a berth or winter storage place requires acceptance of the terms of a contract.",
       "questions": "Questions and further information: ",
       "terms_pdf": "Open contract (PDF)",
+      "terms_notice": "Note. The terms of the agreement must be opened and read before they can be accepted.",
       "terms_checkbox": "I have read and accept the contract terms",
       "terms_form_submit": "Continue to authentication",
       "select_signing_provider": "Sign the contract by choosing an authentication method",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -667,6 +667,7 @@
       "info": "Hyvä asiakkaamme, olemme luoneet teille sopimuksen joka allekirjoitetaan sähköisesti. Tutustu sopimukseen alla. Voit jatkaa tunnistautumiseen ja maksamiseen hyväksyttyäsi sopimusehdot. Vene- tai talvisäilytyspaikan saaminen edellyttää sopimusehtojen hyväksymistä.",
       "questions": "Kysymykset ja lisätiedot: ",
       "terms_pdf": "Avaa sopimusehdot (PDF)",
+      "terms_notice": "Huom. Sopimusehdot täytyy avata ja lukea ennen kuin ne voi hyväksyä.",
       "terms_checkbox": "Olen lukenut sopimusehdot ja hyväksyn ne",
       "terms_form_submit": "Jatka tunnistautumiseen",
       "select_signing_provider": "Allekirjoita sopimus valitsemalla tunnistautumistapa",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -667,6 +667,7 @@
       "info": "Bästa kund, vi har lagt upp ett avtal för dig som ska signeras elektroniskt. Läs avtalet nedan. Då du godkänt avtalsvillkoren, kan du fortsätta till identifikationen och betalningen. För att få en båtplats måste du godkänna avtalsvillkoren.",
       "questions": "Frågor och mer information: ",
       "terms_pdf": "Öppna avtalsvillkoren (PDF)",
+      "terms_notice": "Notera. Villkoren i avtalet måste öppnas och läsas innan de kan accepteras.",
       "terms_checkbox": "Jag har läst avtalsvillkoren och godkänner dem",
       "terms_form_submit": "Fortsätt till identifikationen",
       "select_signing_provider": "Signera avtalet genom att välja identifikationssätt",


### PR DESCRIPTION
## Description :sparkles:

* Add info text in payment page before terms link

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1088](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1088): Add info text in payment page before terms link

## Screenshots :camera_flash:

![image](https://user-images.githubusercontent.com/15479131/105186926-e3063e00-5b3a-11eb-9331-b6f8708bdd5a.png)
