### PR TITLE
VEN-1096 | Add possibility to terminate lease into customer UI payment view

### DIFF
--- a/browser-tests/berth.ts
+++ b/browser-tests/berth.ts
@@ -1,4 +1,4 @@
-import { selectHarborsSelectors } from './selectors/berth';
+import { selectHarborsSelectors, berthSelectors } from './selectors/berth';
 import { navbarSelectors } from './selectors/navbar';
 import { boatInformationSelectors } from './selectors/shared';
 import { ApplicantInformation, BerthBoatInformation, Choices } from './types/types';
@@ -67,13 +67,12 @@ const selectHarbors = async (t: TestController) => {
     getSelectButtonForHarbor,
   } = selectHarborsSelectors;
 
-  const boatTypeOption = Selector(boatTypeSelect.find('option').withText(testData.boatType), {
-    timeout: 30000,
-  });
+  // Wait for the data to be loaded
+  await t.click(berthSelectors.map);
 
   await t
     .click(boatTypeSelect)
-    .click(boatTypeOption)
+    .click(boatTypeSelect.find('option').withText(testData.boatType))
     .expect(boatTypeSelect.value)
     .eql(testData.boatTypeIndex);
 

--- a/browser-tests/berth.ts
+++ b/browser-tests/berth.ts
@@ -9,6 +9,7 @@ import {
   assertOverview,
   swapSelections,
 } from './sharedTests/sharedTests';
+import { Selector } from 'testcafe';
 
 const testData: Choices & BerthBoatInformation & ApplicantInformation = {
   address: 'Testiosoite 1',
@@ -66,9 +67,13 @@ const selectHarbors = async (t: TestController) => {
     getSelectButtonForHarbor,
   } = selectHarborsSelectors;
 
+  const boatTypeOption = Selector(boatTypeSelect.find('option').withText(testData.boatType), {
+    timeout: 30000,
+  });
+
   await t
     .click(boatTypeSelect)
-    .click(boatTypeSelect.find('option').withText(testData.boatType))
+    .click(boatTypeOption)
     .expect(boatTypeSelect.value)
     .eql(testData.boatTypeIndex);
 

--- a/browser-tests/selectors/berth.ts
+++ b/browser-tests/selectors/berth.ts
@@ -23,4 +23,5 @@ export const selectHarborsSelectors = {
 export const berthSelectors = {
   title: Selector('h1[class="vene-hero__title"]'),
   legend: Selector('div[class="vene-berths-legend"]'),
+  map: Selector('div[class="vene-map"]'),
 };

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -17,7 +17,7 @@ import UnmarkedWinterStoragePage from '../components/pages/unmarkedWinterStorage
 
 import { ApplicationType } from '../types/applicationType';
 import { LocaleOpts } from '../types/intl';
-import { PaymentPageContainer } from '../components/pages/paymentPage/PaymentPageContainer';
+import PaymentPageContainer from '../components/pages/paymentPage/PaymentPageContainer';
 import { PaymentResultContainer } from '../components/pages/paymentResultPage/PaymentResultContainer';
 import CancelOrderPageContainer from '../components/pages/cancelOrderPage/CancelOrderPageContainer';
 

--- a/src/components/pages/cancelOrderPage/cancelOrderPage.scss
+++ b/src/components/pages/cancelOrderPage/cancelOrderPage.scss
@@ -25,7 +25,7 @@
 
   &__btn {
     margin-top: $spacing-03;
-    padding: $spacing-01 $spacing-03;
+    padding: $spacing-00-50 $spacing-03;
   }
 
   &__max-width {

--- a/src/components/pages/paymentPage/ContractPage.tsx
+++ b/src/components/pages/paymentPage/ContractPage.tsx
@@ -12,9 +12,10 @@ interface Props {
   orderNumber: string;
   contractAuthMethods: ContractAuthMethods[];
   handleSign: (authMethod: string) => void;
+  handleTerminate: () => void;
 }
 
-const PaymentPage = ({ contractAuthMethods, orderNumber, handleSign }: Props) => {
+const PaymentPage = ({ contractAuthMethods, orderNumber, handleSign, handleTerminate }: Props) => {
   const { t } = useTranslation();
   const [termsOpened, setTermsOpened] = useState<boolean>(false);
   const [termsAccepted, setTermsAccepted] = useState<boolean>(false);
@@ -69,6 +70,13 @@ const PaymentPage = ({ contractAuthMethods, orderNumber, handleSign }: Props) =>
                 </div>
               )}
             </Form>
+
+            <div>
+              <p>{t('page.contract.termination_note')}</p>
+              <Button color="danger" onClick={handleTerminate} outline>
+                {t('page.contract.terminate')}
+              </Button>
+            </div>
 
             {termsAccepted && (
               <div>

--- a/src/components/pages/paymentPage/PaymentPageContainer.tsx
+++ b/src/components/pages/paymentPage/PaymentPageContainer.tsx
@@ -5,7 +5,7 @@ import { compose } from 'recompose';
 import PaymentPage from './PaymentPage';
 import ContractPage from './ContractPage';
 import { CONFIRM_PAYMENT, FULFILL_CONTRACT, GET_ORDER_DETAILS } from '../../../utils/graphql';
-import { getOrderNumber } from '../../../utils/urls';
+import { getOrderNumber, setOrderNumber } from '../../../utils/urls';
 import GeneralPaymentErrorPage from './paymentError/GeneralPaymentErrorPage';
 import AlreadyPaidPage from './paymentError/AlreadyPaidPage';
 import PastDueDatePage from './paymentError/PastDueDatePage';
@@ -81,7 +81,7 @@ const PaymentPageContainer = ({ localePush }: Props) => {
   };
 
   const handleTerminate = () => {
-    localePush('cancel-order');
+    localePush(setOrderNumber('cancel-order', orderNumber));
   };
 
   if (confirmError || orderDetailsError) {

--- a/src/components/pages/paymentPage/PaymentPageContainer.tsx
+++ b/src/components/pages/paymentPage/PaymentPageContainer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useMutation, useQuery } from '@apollo/react-hooks';
+import { compose } from 'recompose';
 
 import PaymentPage from './PaymentPage';
 import ContractPage from './ContractPage';
@@ -9,6 +10,7 @@ import GeneralPaymentErrorPage from './paymentError/GeneralPaymentErrorPage';
 import AlreadyPaidPage from './paymentError/AlreadyPaidPage';
 import PastDueDatePage from './paymentError/PastDueDatePage';
 import LoadingPage from '../../../common/loadingPage/LoadingPage';
+import { LocalePush, withMatchParamsHandlers } from '../../../utils/container';
 import {
   ConfirmPayment,
   ConfirmPaymentVariables,
@@ -24,7 +26,11 @@ import {
   FulfillContractVariables,
 } from '../../../utils/__generated__/FulfillContract';
 
-const PaymentPageContainer = () => {
+interface Props {
+  localePush: LocalePush;
+}
+
+const PaymentPageContainer = ({ localePush }: Props) => {
   const orderNumber = getOrderNumber(window.location.search);
 
   const [isRedirecting, setIsRedirecting] = useState(false);
@@ -74,6 +80,10 @@ const PaymentPageContainer = () => {
     });
   };
 
+  const handleTerminate = () => {
+    localePush('cancel-order');
+  };
+
   if (confirmError || orderDetailsError) {
     return <GeneralPaymentErrorPage />;
   }
@@ -93,7 +103,8 @@ const PaymentPageContainer = () => {
     orderDetailsData?.orderDetails?.status,
     orderDetailsData?.contractAuthMethods ?? [],
     confirmPayment,
-    handleSignContract
+    handleSignContract,
+    handleTerminate
   );
 };
 
@@ -104,7 +115,8 @@ export const getPaymentPage = (
   status: OrderStatus | undefined | null,
   contractAuthMethods: ContractAuthMethods[],
   confirmPayment: () => void,
-  signContract: (authMethod: string) => void
+  signContract: (authMethod: string) => void,
+  handleTerminate: () => void
 ): JSX.Element => {
   if (!status) {
     return <GeneralPaymentErrorPage />;
@@ -115,6 +127,7 @@ export const getPaymentPage = (
       <ContractPage
         orderNumber={orderNumber}
         handleSign={signContract}
+        handleTerminate={handleTerminate}
         contractAuthMethods={contractAuthMethods}
       />
     );
@@ -134,4 +147,4 @@ export const getPaymentPage = (
   }
 };
 
-export { PaymentPageContainer };
+export default compose<Props, Props>(withMatchParamsHandlers)(PaymentPageContainer);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -669,7 +669,9 @@
       "terms_pdf": "Open contract (PDF)",
       "terms_checkbox": "I have read and accept the contract terms",
       "terms_form_submit": "Continue to authentication",
-      "select_signing_provider": "Sign the contract by choosing an authentication method"
+      "select_signing_provider": "Sign the contract by choosing an authentication method",
+      "termination_note": "I want to give up my berth and I don’t want to pay for it anymore.",
+      "terminate": "Terminate the berth"
     },
     "payment": {
       "title": "Paying the invoice",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -669,7 +669,9 @@
       "terms_pdf": "Avaa sopimusehdot (PDF)",
       "terms_checkbox": "Olen lukenut sopimusehdot ja hyväksyn ne",
       "terms_form_submit": "Jatka tunnistautumiseen",
-      "select_signing_provider": "Allekirjoita sopimus valitsemalla tunnistautumistapa"
+      "select_signing_provider": "Allekirjoita sopimus valitsemalla tunnistautumistapa",
+      "termination_note": "Haluan luopua venepaikastani enkä halua enää maksaa sitä.",
+      "terminate": "Irtisano venepaikka"
     },
     "payment": {
       "title": "Laskun maksaminen",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -669,7 +669,9 @@
       "terms_pdf": "Öppna avtalsvillkoren (PDF)",
       "terms_checkbox": "Jag har läst avtalsvillkoren och godkänner dem",
       "terms_form_submit": "Fortsätt till identifikationen",
-      "select_signing_provider": "Signera avtalet genom att välja identifikationssätt"
+      "select_signing_provider": "Signera avtalet genom att välja identifikationssätt",
+      "termination_note": "Jag vill ge upp min kaj och vill inte betala för den längre.",
+      "terminate": "Avsluta båtplats"
     },
     "payment": {
       "title": "Betalning av fakturan",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -671,7 +671,7 @@
       "terms_form_submit": "Fortsätt till identifikationen",
       "select_signing_provider": "Signera avtalet genom att välja identifikationssätt",
       "termination_note": "Jag vill ge upp min kaj och vill inte betala för den längre.",
-      "terminate": "Avsluta båtplats"
+      "terminate": "Avsluta båtplatsen"
     },
     "payment": {
       "title": "Betalning av fakturan",

--- a/src/utils/formValidation.ts
+++ b/src/utils/formValidation.ts
@@ -1,8 +1,9 @@
 export const stringHasNoExtraWhitespace = (value: string): boolean =>
   value.charAt(0) !== ' ' && value.charAt(value.length - 1) !== ' ';
 
-export const mustBePresent = (value: any): string | undefined => {
-  if (value && value.trim().length > 0) return undefined;
+export const mustBePresent = (value: unknown): string | undefined => {
+  if (typeof value === 'string' && value.trim().length > 0) return undefined;
+  if (value) return undefined;
   return 'validation.message.required';
 };
 

--- a/src/utils/formValidation.ts
+++ b/src/utils/formValidation.ts
@@ -2,9 +2,12 @@ export const stringHasNoExtraWhitespace = (value: string): boolean =>
   value.charAt(0) !== ' ' && value.charAt(value.length - 1) !== ' ';
 
 export const mustBePresent = (value: unknown): string | undefined => {
-  if (typeof value === 'string' && value.trim().length > 0) return undefined;
+  const errorMsg = 'validation.message.required';
+
+  if (typeof value === 'string') return value.trim().length ? undefined : errorMsg;
   if (value) return undefined;
-  return 'validation.message.required';
+
+  return errorMsg;
 };
 
 export const mustBeNames = (maxNames: number) => (value: any): string | undefined => {

--- a/src/utils/urls.test.ts
+++ b/src/utils/urls.test.ts
@@ -1,4 +1,4 @@
-import { getOrderNumber, getPaymentSuccess } from './urls';
+import { getOrderNumber, getPaymentSuccess, setOrderNumber } from './urls';
 
 describe('utils/urls', () => {
   describe('getOrderNumber', () => {
@@ -15,6 +15,12 @@ describe('utils/urls', () => {
       expect(getPaymentSuccess('?payment_status=failure')).toBeFalsy();
       expect(getPaymentSuccess('?payment_status=')).toBeFalsy();
       expect(getPaymentSuccess('?foo=bar')).toBeFalsy();
+    });
+  });
+
+  describe('setOrderNumber', () => {
+    it('should return the provided url and the order_number query', () => {
+      expect(setOrderNumber('foo', '123')).toEqual('foo?order_number=123');
     });
   });
 });

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -10,6 +10,12 @@ export const getOrderNumber = (searchString: string): string => {
   return orderNumber;
 };
 
+export const setOrderNumber = (url: string, orderNumber: string): string => {
+  const stringified = queryString.stringify({ order_number: orderNumber });
+
+  return `${url}?${stringified}`;
+};
+
 export const getPaymentSuccess = (searchString: string): boolean => {
   const parsed = queryString.parse(searchString);
   const paymentStatus = parsed.payment_status;


### PR DESCRIPTION
## Description :sparkles:
- Add a button that leads to the [`cancel order`](https://venepaikka.test.kuva.hel.ninja/fi/cancel-order) page

### Closes :no_good_woman:
[VEN-1096](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1096): Add possibility to terminate lease into customer UI payment view

## Testing :alembic:

### Automated tests :gear:️
Added tests:
https://github.com/City-of-Helsinki/berth-reservations-ui/blob/b3821a828d04d3868a3e8c0f3db056955c17ba82/src/utils/urls.test.ts#L21

### Manual testing :construction_worker_man:
- From the [payment page](http://localhost:3000/sv/payment?order_number=ajor7vexqi3qa)
- Click on `Irtisano venepaikka` button
- The user should be directed to the [`cancel order`](https://venepaikka.test.kuva.hel.ninja/fi/cancel-order) page
- By following the steps on the cancellation page the lease should be terminated

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/105360163-fa0f6380-5c00-11eb-8d83-0fbc8a37e19a.png)


