### PR TITLE
VEN-1102 | Customer contact information view

### DIFF
--- a/src/features/profile/ProfilePage.tsx
+++ b/src/features/profile/ProfilePage.tsx
@@ -5,15 +5,17 @@ import { useTranslation } from 'react-i18next';
 import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
 
 import Layout from '../../common/layout/Layout';
+import ContactInfo, { ContactInfoProps } from './contactInfo/ContactInfo';
 
 import './profilePage.scss';
 
 export interface ProfilePageProps {
+  customerContactInfo: ContactInfoProps;
   hasBerthNotifications: boolean;
   hasWSNotifications: boolean;
 }
 
-const ProfilePage = ({ hasBerthNotifications, hasWSNotifications }: ProfilePageProps) => {
+const ProfilePage = ({ customerContactInfo, hasBerthNotifications, hasWSNotifications }: ProfilePageProps) => {
   const { t } = useTranslation();
   const [isBerthTabClicked, setIsBerthTabClicked] = useState(false);
   const [isWSTabClicked, setIsWSTabClicked] = useState(false);
@@ -47,7 +49,9 @@ const ProfilePage = ({ hasBerthNotifications, hasWSNotifications }: ProfilePageP
                 </span>
               </Tab>
             </TabList>
-            <TabPanel>Contact information tab</TabPanel>
+            <TabPanel>
+              <ContactInfo {...customerContactInfo} />
+            </TabPanel>
             <TabPanel>Boats tab</TabPanel>
             <TabPanel>Berths tab</TabPanel>
             <TabPanel>Winter storage tab</TabPanel>

--- a/src/features/profile/ProfilePageContainer.tsx
+++ b/src/features/profile/ProfilePageContainer.tsx
@@ -5,7 +5,7 @@ import ProfilePage from './ProfilePage';
 const ProfilePageContainer = () => {
   const customerContactInfo = {
     name: 'Kalle',
-    address: 'Kallenkau 6',
+    address: 'Kallenkatu 6',
     postalCode: '00100',
     municipality: 'Helsinki',
     phoneNumber: '-',

--- a/src/features/profile/ProfilePageContainer.tsx
+++ b/src/features/profile/ProfilePageContainer.tsx
@@ -3,7 +3,20 @@ import React from 'react';
 import ProfilePage from './ProfilePage';
 
 const ProfilePageContainer = () => {
-  return <ProfilePage hasBerthNotifications={true} hasWSNotifications={false} />;
+  const customerContactInfo = {
+    name: 'Kalle',
+    address: 'Kallenkau 6',
+    postalCode: '00100',
+    municipality: 'Helsinki',
+    phoneNumber: '-',
+    emailAddress: 'kalle@gmail.com',
+    customerGroup: 'Yksityinen',
+    language: 'Suomi',
+  };
+
+  return (
+    <ProfilePage customerContactInfo={customerContactInfo} hasBerthNotifications={true} hasWSNotifications={false} />
+  );
 };
 
 export default ProfilePageContainer;

--- a/src/features/profile/contactInfo/ContactInfo.tsx
+++ b/src/features/profile/contactInfo/ContactInfo.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import LabelValuePair from '../../../common/labelValuePair/LabelValuePair';
+import './contactInfo.scss';
+
+export interface ContactInfoProps {
+  name: string;
+  address: string;
+  postalCode: string;
+  municipality: string;
+  phoneNumber: string;
+  emailAddress: string;
+  customerGroup: string;
+  language: string;
+}
+
+const ContactInfo = ({
+  name,
+  address,
+  postalCode,
+  municipality,
+  phoneNumber,
+  emailAddress,
+  customerGroup,
+  language,
+}: ContactInfoProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="vene-contact-info">
+      <h1>{t('page.profile.contact.heading', { name })}</h1>
+      <div className="vene-contact-info__section">
+        <LabelValuePair label={t('page.profile.contact.address')} value={address} />
+        <LabelValuePair label={t('page.profile.contact.postal_code')} value={postalCode} />
+        <LabelValuePair label={t('page.profile.contact.municipality')} value={municipality} />
+      </div>
+      <div className="vene-contact-info__section">
+        <LabelValuePair label={t('page.profile.contact.phone_number')} value={phoneNumber} />
+        <LabelValuePair label={t('page.profile.contact.email_address')} value={emailAddress} />
+      </div>
+      <div className="vene-contact-info__section">
+        <LabelValuePair label={t('page.profile.contact.customer_group')} value={customerGroup} />
+        <LabelValuePair label={t('page.profile.contact.language')} value={language} />
+      </div>
+    </div>
+  );
+};
+
+export default ContactInfo;

--- a/src/features/profile/contactInfo/contactInfo.scss
+++ b/src/features/profile/contactInfo/contactInfo.scss
@@ -1,0 +1,7 @@
+@import 'styles/variables';
+
+.vene-contact-info {
+  &__section {
+    margin-bottom: $spacing-01-50;
+  }
+}

--- a/src/features/profile/profilePage.scss
+++ b/src/features/profile/profilePage.scss
@@ -11,15 +11,12 @@
   }
 
   &__tab {
-    color: 'black';
     // Adjusting the colors here until HDS supports themes for Tabs
     --tab-color: black;
     --tab-active-border-color: black;
 
-    &--with-badge {
-      & span {
-        padding: 0;
-      }
+    &--with-badge > span {
+      padding: 0;
     }
   }
 

--- a/src/features/profile/profilePage.scss
+++ b/src/features/profile/profilePage.scss
@@ -23,7 +23,7 @@
     }
   }
 
-  &__tab-content {
+  &__label {
     &--with-badge {
       &::after {
         content: '';

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -682,7 +682,15 @@
     },
     "profile": {
       "contact": {
-        "title": "Contact information"
+        "title": "Contact information",
+        "heading": "Hello {{ name }}",
+        "address": "Street address",
+        "postal_code": "Postal code",
+        "municipality": "City",
+        "phone_number": "Mobile phone",
+        "email_address": "E-mail",
+        "customer_group": "Customer group",
+        "language": "Language"
       },
       "boats": {
         "title": "Boats"

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -682,7 +682,15 @@
     },
     "profile": {
       "contact": {
-        "title": "Yhteystiedot"
+        "title": "Yhteystiedot",
+        "heading": "Hei {{ name }}",
+        "address": "Jakeluosoite",
+        "postal_code": "Postinumero",
+        "municipality": "Postitoimipaikka",
+        "phone_number": "Matkapuhelin",
+        "email_address": "Sähköpostiosoite",
+        "customer_group": "Asiakasryhmä",
+        "language": "Asiointikieli"
       },
       "boats": {
         "title": "Veneet"

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -682,7 +682,15 @@
     },
     "profile": {
       "contact": {
-        "title": "Kontaktinformation"
+        "title": "Kontaktinformation",
+        "heading": "Hallå {{ name }}",
+        "address": "Utdelningsadress",
+        "postal_code": "Postnummer",
+        "municipality": "Postanstalt",
+        "phone_number": "Mobiltelefon",
+        "email_address": "E-postadress",
+        "customer_group": "Kundgrupp",
+        "language": "Språk"
       },
       "boats": {
         "title": "Båtar"

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -690,7 +690,7 @@
         "phone_number": "Mobiltelefon",
         "email_address": "E-postadress",
         "customer_group": "Kundgrupp",
-        "language": "Språk"
+        "language": "Språket"
       },
       "boats": {
         "title": "Båtar"


### PR DESCRIPTION
## Description :sparkles:
- Implement the ContactInformation component
- Pass the mock data down from the container to the corresponding tab

## Issues :bug:
[VEN-1102](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1102): Customer contact information page

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:
- Check the contact information tab from [the profile page](https://venepaikka.test.kuva.hel.ninja/fi/profile)

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/107378041-43621d00-6af4-11eb-90d2-1380511a1299.png)

## Additional notes :spiral_notepad:

