### PR TITLE
VEN-1145 | Add missing REACT_APP_API_URL_ROOT to GitHub workflows

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -30,6 +30,7 @@ jobs:
         env:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-production
           DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://api.hel.fi/berths/graphql/'
+          DOCKER_BUILD_ARG_REACT_APP_API_URL_ROOT: 'https://api.hel.fi/berths/'
           DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'production'
           DOCKER_BUILD_ARG_REACT_APP_SENTRY_ENVIRONMENT: 'production'
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-review
           DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://venepaikka-api.test.kuva.hel.ninja/graphql/'
+          DOCKER_BUILD_ARG_REACT_APP_API_URL_ROOT: 'https://venepaikka-api.test.kuva.hel.ninja/'
           DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'development'
           DOCKER_BUILD_ARG_REACT_APP_SENTRY_ENVIRONMENT: 'review'
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -30,6 +30,7 @@ jobs:
         env:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-staging
           DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://venepaikka-api.test.kuva.hel.ninja/graphql/'
+          DOCKER_BUILD_ARG_REACT_APP_API_URL_ROOT: 'https://venepaikka-api.test.kuva.hel.ninja/'
           DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'development'
           DOCKER_BUILD_ARG_REACT_APP_SENTRY_ENVIRONMENT: 'staging'
 


### PR DESCRIPTION
## Description :sparkles:

* Add missing REACT_APP_API_URL_ROOT to GitHub workflows

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1145](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1145): Payments terms and conditions link shows 404 page
