### PR TITLE
VEN-1120 | Add success page for cancelling invoice/berth

### DIFF
--- a/browser-tests/selectors/shared.ts
+++ b/browser-tests/selectors/shared.ts
@@ -43,9 +43,8 @@ export const overviewSelectors = {
     const pairs: string[] = [];
     for (let i = 0; i < labelValuePairCount; i += 1) {
       const label = await labelValuePairs.nth(i).child(0).textContent;
-      // Skipping index 1 because it is just ':'
-      const value = await labelValuePairs.nth(i).child(2).textContent;
-      pairs.push(`${label}: ${value}`);
+      const value = await labelValuePairs.nth(i).child(1).textContent;
+      pairs.push(`${label} ${value}`);
     }
     return pairs.join('\n');
   },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "i18next": "^19.8.7",
     "immutable": "^4.0.0-rc.12",
     "leaflet": "^1.7.1",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "node-sass": "^5.0.0",
     "open-city-design": "^1.0.0-alpha.3",
     "piwik-react-router": "^0.12.1",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -20,6 +20,7 @@ import PaymentPageContainer from '../features/payment/paymentPage/PaymentPageCon
 import { PaymentResultContainer } from '../features/payment/paymentResultPage/PaymentResultContainer';
 import CancelOrderPageContainer from '../features/payment/cancelOrderPage/CancelOrderPageContainer';
 import ProfilePageContainer from '../features/profile/ProfilePageContainer';
+import OrderCancelledPage from '../features/payment/cancelOrderPage/OrderCancelledPage';
 
 type Props = RouteComponentProps<{ locale: LocaleOpts }>;
 
@@ -55,6 +56,7 @@ const App = ({
       <Route exact path={`/${localeParam}/payment`} component={PaymentPageContainer} />
       <Route exact path={`/${localeParam}/payment-result`} component={PaymentResultContainer} />
       <Route exact path={`/${localeParam}/cancel-order`} component={CancelOrderPageContainer} />
+      <Route exact path={`/${localeParam}/order-cancelled`} component={OrderCancelledPage} />
 
       <Route exact path={`/${localeParam}/profile`} component={ProfilePageContainer} />
 

--- a/src/features/payment/cancelOrderPage/CancelOrderPageContainer.tsx
+++ b/src/features/payment/cancelOrderPage/CancelOrderPageContainer.tsx
@@ -23,7 +23,7 @@ const CancelOrderPageContainer = ({ localePush }: Props) => {
       },
     },
     onCompleted: () => {
-      localePush('/');
+      localePush('/order-cancelled');
     },
   });
 

--- a/src/features/payment/cancelOrderPage/OrderCancelledPage.tsx
+++ b/src/features/payment/cancelOrderPage/OrderCancelledPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import NoticeTemplate from '../../../common/noticeTemplate/NoticeTemplate';
+
+const OrderCancelledPage = () => {
+  const { t } = useTranslation();
+
+  return (
+    <NoticeTemplate titleText={t('page.order_cancelled.title_text')} message={t('page.order_cancelled.message')} />
+  );
+};
+
+export default OrderCancelledPage;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -577,6 +577,10 @@
       "confirmation": "I want to cancel the offer/invoice",
       "submit_button": "OK"
     },
+    "order_cancelled": {
+      "title_text": "The cancellation was successful!",
+      "message": "We have received the cancellation and your berth has been terminated. You will receive a confirmation to your email."
+    },
     "common": {
       "website": "Website"
     },

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -608,6 +608,10 @@
       "confirmation": "Haluan peruuttaa tarjouksen/laskun",
       "submit_button": "OK"
     },
+    "order_cancelled": {
+      "title_text": "Peruuttaminen onnistui!",
+      "message": "Olemme vastaanottaneet peruutuksen ja paikkasi on irtisanottu. Saat tästä vielä vahvistuksen sähköpostiisi."
+    },
     "common": {
       "website": "Verkkosivu"
     },

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -577,6 +577,10 @@
       "confirmation": "Jag vill annullera erbjudandet/fakturan",
       "submit_button": "OK"
     },
+    "order_cancelled": {
+      "title_text": "Avbokningen lyckades!",
+      "message": "Vi har fått avbokningen och din båtplats har avslutats. Du kommer att få en bekräftelse på din e-post."
+    },
     "common": {
       "website": "Webbplats"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9717,10 +9717,10 @@ lodash.xorby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.xorby/-/lodash.xorby-4.7.0.tgz#9c19a6f9f063a6eb53dd03c1b6871799801463d7"
   integrity sha1-nBmm+fBjputT3QPBtocXmYAUY9c=
 
-"lodash@4.6.1 || ^4.16.1", "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5, lodash@~4.17.10:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+"lodash@4.6.1 || ^4.16.1", "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@~4.17.10:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Description :sparkles:

* Add success page for cancelling invoice/berth

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1120](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1120): Add success page for cancelling invoice/berth

## Testing :alembic:

### Manual testing :construction_worker_man:

* Once an order is cancelled, the user should be redirected to the success page
* The page is at URL `/fi/order-cancelled`

