### PR TITLE
VEN-1110 | Customer Profile Page Fixes

### DIFF
--- a/src/features/profile/ProfilePage.tsx
+++ b/src/features/profile/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import { Container } from 'reactstrap';
 import { useTranslation } from 'react-i18next';
@@ -24,8 +24,6 @@ const ProfilePage = ({
   hasWSNotifications,
 }: ProfilePageProps) => {
   const { t } = useTranslation();
-  const [isBerthTabClicked, setIsBerthTabClicked] = useState(false);
-  const [isWSTabClicked, setIsWSTabClicked] = useState(false);
 
   return (
     <Layout>
@@ -35,25 +33,19 @@ const ProfilePage = ({
             <TabList className="vene-profile-page__tablist">
               <Tab className="vene-profile-page__tab">{t('page.profile.contact.title')}</Tab>
               <Tab className="vene-profile-page__tab">{t('page.profile.boats.title')}</Tab>
-              <Tab className={classNames('vene-profile-page__tab', 'vene-profile-page__tab--with-badge')}>
-                <span
-                  onMouseDown={() => setIsBerthTabClicked(true)}
-                  className={classNames('vene-profile-page__label', {
-                    'vene-profile-page__label--with-badge': hasBerthNotifications && !isBerthTabClicked,
-                  })}
-                >
-                  {t('page.profile.berths.title')}
-                </span>
+              <Tab
+                className={classNames('vene-profile-page__tab', {
+                  'vene-profile-page__tab--with-badge': hasBerthNotifications,
+                })}
+              >
+                {t('page.profile.berths.title')}
               </Tab>
-              <Tab className={classNames('vene-profile-page__tab', 'vene-profile-page__tab--with-badge')}>
-                <span
-                  onMouseDown={() => setIsWSTabClicked(true)}
-                  className={classNames('vene-profile-page__label', {
-                    'vene-profile-page__label--with-badge': hasWSNotifications && !isWSTabClicked,
-                  })}
-                >
-                  {t('page.profile.winter_storage.title')}
-                </span>
+              <Tab
+                className={classNames('vene-profile-page__tab', {
+                  'vene-profile-page__tab--with-badge': hasWSNotifications,
+                })}
+              >
+                {t('page.profile.winter_storage.title')}
               </Tab>
             </TabList>
             <TabPanel>

--- a/src/features/profile/customerBerths/CustomerBerths.tsx
+++ b/src/features/profile/customerBerths/CustomerBerths.tsx
@@ -34,7 +34,7 @@ const CustomerBerths = ({ application, offer, invoice, reservations }: CustomerB
       )}
       {application && (
         <>
-          <BerthApplication {...application} showHeading={!offer && !invoice} />
+          <BerthApplication {...application} showHeading={!offer && !invoice} disableButtons={!!offer} />
           <hr className="vene-berth-offer__divider" />
         </>
       )}

--- a/src/features/profile/customerBerths/berthApplication/BerthApplication.tsx
+++ b/src/features/profile/customerBerths/berthApplication/BerthApplication.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox } from 'hds-react';
+import { Button } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -24,9 +24,10 @@ export interface BerthApplicationProps {
   applicationDate: string;
   berthChoices: BerthChoice[];
   showHeading?: boolean;
+  disableButtons?: boolean;
 }
 
-const BerthApplication = ({ applicationDate, berthChoices, showHeading }: BerthApplicationProps) => {
+const BerthApplication = ({ applicationDate, berthChoices, showHeading, disableButtons }: BerthApplicationProps) => {
   const {
     t,
     i18n: { language },
@@ -72,10 +73,10 @@ const BerthApplication = ({ applicationDate, berthChoices, showHeading }: BerthA
       /> */}
 
       <div className="vene-berth-application__buttons">
-        <Button size="small" variant="secondary" disabled>
+        <Button size="small" variant="secondary" disabled={disableButtons}>
           {t('page.profile.berths.berth_offer.edit_application')}
         </Button>
-        <Button size="small" variant="secondary" disabled>
+        <Button size="small" variant="danger" disabled={disableButtons}>
           {t('page.profile.berths.berth_offer.delete_application')}
         </Button>
       </div>

--- a/src/features/profile/customerBerths/berthApplication/BerthApplication.tsx
+++ b/src/features/profile/customerBerths/berthApplication/BerthApplication.tsx
@@ -64,11 +64,12 @@ const BerthApplication = ({ applicationDate, berthChoices, showHeading }: BerthA
       <h2 className="vene-berth-application__heading">{t('page.profile.berths.berth_offer.applied_berths')}</h2>
       <div className="vene-berth-application__applied-berths">{berthChoices.map(renderAppliedBerth)}</div>
 
+      {/* Removing the checkbox until the design is ready
       <Checkbox
         checked
         id="keep-application-active"
         labelText={t('page.profile.berths.berth_offer.keep_application_active')}
-      />
+      /> */}
 
       <div className="vene-berth-application__buttons">
         <Button size="small" variant="secondary" disabled>

--- a/src/features/profile/profilePage.scss
+++ b/src/features/profile/profilePage.scss
@@ -11,16 +11,11 @@
   }
 
   &__tab {
+    position: relative;
     // Adjusting the colors here until HDS supports themes for Tabs
     --tab-color: black;
     --tab-active-border-color: black;
 
-    &--with-badge > span {
-      padding: 0 !important;
-    }
-  }
-
-  &__label {
     &--with-badge {
       &::after {
         content: '';
@@ -31,7 +26,7 @@
         border-radius: 50%;
         position: absolute;
         top: 0;
-        right: $spacing-00-75;
+        right: $spacing-00-25;
       }
     }
   }


### PR DESCRIPTION
## Description :sparkles:
- Keep the red navigation indicator active until the invoice status is paid or rejected/terminated
- Remove the checkbox `Haluan että hakemus jää voimaan…`
- Pass a prop for enabling and disabling `Muokkaa hakemusta` & `Poista hakemus` buttons

## Issues :bug:

### Closes :no_good_woman:
[VEN-1110](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1110): Customer Berths page - Application

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:
- Go through the profile page for the following users:
  - Application sent: https://venepaikka.test.kuva.hel.ninja/fi/profile/1
  - Offer sent: https://venepaikka.test.kuva.hel.ninja/fi/profile/2 
  - Recurring invoices: https://venepaikka.test.kuva.hel.ninja/fi/profile/3
  - Invoice Paid: https://venepaikka.test.kuva.hel.ninja/fi/profile/4
  - No berths: https://venepaikka.test.kuva.hel.ninja/fi/profile/5

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

