### PR TITLE
VEN-1153 | Improve customer name validation

### DIFF
--- a/src/common/applicantDetails/tabs/fragments/FullName.tsx
+++ b/src/common/applicantDetails/tabs/fragments/FullName.tsx
@@ -12,7 +12,7 @@ const FullName = () => (
         label="form.private_person.field.first_name.label"
         placeholder="form.private_person.field.first_name.placeholder"
         required
-        validate={mustBeNames(4)}
+        validate={mustBeNames(5)}
       />
     </Col>
     <Col sm={4}>
@@ -21,7 +21,7 @@ const FullName = () => (
         label="form.private_person.field.last_name.label"
         placeholder="form.private_person.field.last_name.placeholder"
         required
-        validate={mustBeNames(1)}
+        validate={mustBeNames(5)}
       />
     </Col>
   </Row>

--- a/src/common/utils/formValidation.ts
+++ b/src/common/utils/formValidation.ts
@@ -11,8 +11,8 @@ export const mustBePresent = (value: unknown): string | undefined => {
 };
 
 export const mustBeNames = (maxNames: number) => (value: string): string | undefined => {
-  const regexString = `^([\\p{Script_Extensions=Latin}-]+\\s*){1,${maxNames}}$`;
-  const regex = RegExp(regexString, 'u');
+  const regexString = `^([a-zA-Z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u017F-]+\\s*){1,${maxNames}}$`;
+  const regex = RegExp(regexString);
 
   if (regex.test(value) && stringHasNoExtraWhitespace(value)) {
     return undefined;


### PR DESCRIPTION
## Description :sparkles:

* Allow more words in names (5 for first and last name)
* Make validation compatible with browsers that don't support Unicode options for regular expressions

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1153](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1153): Customer UI validation error of the customer's name

## Testing :alembic:

### Automated tests :gear:️
* Existing tests suggest that the new validation schema works as expected

### Manual testing :construction_worker_man:
* All names with 5 words of legally accepted characters should be valid
* Validation should work on iPad
