### PR TITLE
VEN-1204, VEN-1290 | Fixes related to switch offers

### DIFF
--- a/src/common/types/applicationType.ts
+++ b/src/common/types/applicationType.ts
@@ -1,6 +1,6 @@
 export enum ApplicationOptions {
   NewApplication = 'new_application',
-  ExchangeApplication = 'exchange_application',
+  SwitchApplication = 'switch_application',
 }
 
 export enum ApplicationType {

--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -321,4 +321,4 @@ export const MUNICIPALITIES = [
   { id: 'äänekoski', translations: { sv: 'Äänekoski', fi: 'Äänekoski' } },
 ];
 
-export const EXCHANGE_APPLICATION_LIMIT = 5;
+export const SWITCH_APPLICATION_LIMIT = 5;

--- a/src/common/withApplicationType/__tests__/withApplicationType.test.tsx
+++ b/src/common/withApplicationType/__tests__/withApplicationType.test.tsx
@@ -37,11 +37,11 @@ describe('withApplicationType', () => {
       expect(wrapper.find(Component).prop('applicationType')).toBe('site.steps.title.berths.new');
     });
 
-    test('Exchange application: the value of "applicationType" should be "site.steps.title.berths.exchange"', () => {
+    test('Switch application: the value of "applicationType" should be "site.steps.title.berths.switch"', () => {
       const WrappedComponent = getApplicationType(Component);
       const wrapper = shallow(
         <WrappedComponent
-          appType={ApplicationOptions.ExchangeApplication}
+          appType={ApplicationOptions.SwitchApplication}
           match={{
             params: { app: ApplicationType.BerthApp },
             isExact: true,
@@ -51,7 +51,7 @@ describe('withApplicationType', () => {
         />
       );
 
-      expect(wrapper.find(Component).prop('applicationType')).toBe('site.steps.title.berths.exchange');
+      expect(wrapper.find(Component).prop('applicationType')).toBe('site.steps.title.berths.switch');
     });
   });
 

--- a/src/common/withApplicationType/withApplicationType.tsx
+++ b/src/common/withApplicationType/withApplicationType.tsx
@@ -21,8 +21,8 @@ export const getApplicationType = (Component: React.ComponentType<{ applicationT
     applicationType = 'site.steps.title.winter_storage';
   } else if (match.params.app === ApplicationType.BerthApp) {
     applicationType =
-      appType === ApplicationOptions.ExchangeApplication
-        ? 'site.steps.title.berths.exchange'
+      appType === ApplicationOptions.SwitchApplication
+        ? 'site.steps.title.berths.switch'
         : 'site.steps.title.berths.new';
   }
 

--- a/src/features/berth/berthFormPage/BerthFormPageContainer.tsx
+++ b/src/features/berth/berthFormPage/BerthFormPageContainer.tsx
@@ -142,7 +142,7 @@ const BerthFormPageContainer = ({
       boatWeight: stringToFloat(values.boatWeight),
     });
 
-    // Append berthSwitch property only when exchange application is selected.
+    // Append berthSwitch property only when switch application is selected.
     const payload = Object.assign(
       {},
       {
@@ -151,7 +151,7 @@ const BerthFormPageContainer = ({
           choices,
         },
       },
-      ApplicationOptions.ExchangeApplication === application.berthsApplicationType && {
+      ApplicationOptions.SwitchApplication === application.berthsApplicationType && {
         berthSwitch: application.berthSwitch,
       }
     );

--- a/src/features/berth/berthFormPage/overview/BerthOverviewInfo.tsx
+++ b/src/features/berth/berthFormPage/overview/BerthOverviewInfo.tsx
@@ -40,8 +40,8 @@ const BerthOverviewInfo = ({
 
   return (
     <OverviewInfo title={applicationType}>
-      {application && application.berthsApplicationType === ApplicationOptions.ExchangeApplication && (
-        <LinkedEditSection title="page.berth.exchange_application.current_berth.title" link="berths/selected">
+      {application && application.berthsApplicationType === ApplicationOptions.SwitchApplication && (
+        <LinkedEditSection title="page.berth.switch_application.current_berth.title" link="berths/selected">
           <OldBerthInfo application={application} />
         </LinkedEditSection>
       )}

--- a/src/features/berth/berthFormPage/overview/oldBerthInfo/OldBerthInfo.tsx
+++ b/src/features/berth/berthFormPage/overview/oldBerthInfo/OldBerthInfo.tsx
@@ -14,13 +14,13 @@ const OldBerthInfo = ({ harborName, pier, berthNumber, reasonTitle }: OldBerthIn
   return (
     <Row>
       <Col xs={12}>
-        <LabelValuePair label="page.berth.exchange_application.form.current_harbour_area.label" value={harborName} />
+        <LabelValuePair label="page.berth.switch_application.form.current_harbour_area.label" value={harborName} />
 
-        <LabelValuePair label="page.berth.exchange_application.form.pier.title" value={pier} />
+        <LabelValuePair label="page.berth.switch_application.form.pier.title" value={pier} />
 
-        <LabelValuePair label="page.berth.exchange_application.form.berth.title" value={berthNumber} />
+        <LabelValuePair label="page.berth.switch_application.form.berth.title" value={berthNumber} />
 
-        <LabelValuePair label="page.berth.exchange_application.reason.title" value={reasonTitle} />
+        <LabelValuePair label="page.berth.switch_application.reason.title" value={reasonTitle} />
       </Col>
     </Row>
   );

--- a/src/features/berth/berthFormPage/overview/oldBerthInfo/OldBerthInfoContainer.tsx
+++ b/src/features/berth/berthFormPage/overview/oldBerthInfo/OldBerthInfoContainer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useQuery } from 'react-apollo';
 
-import { BoatTypesBerthsQuery_harbors_edges_node as Harbor } from '../../../../__generated__/BoatTypesBerthsQuery';
+import { HarborNameQuery } from '../../../../__generated__/HarborNameQuery';
 import { BERTH_SWITCH_REASONS_QUERY, GET_HARBOR_NAME } from '../../../../queries';
 import { ApplicationState } from '../../../../../redux/types';
 import {
@@ -17,8 +17,10 @@ type OldBerthInfoContainerProps = {
 const OldBerthInfoContainer = ({ application }: OldBerthInfoContainerProps) => {
   const isReason = (reason: Reason | null): reason is Reason => reason !== null;
 
-  const { data: harborData } = useQuery<Harbor, { id: string }>(GET_HARBOR_NAME(application.berthSwitch.harborId));
-  const harborName = harborData?.properties?.name || application.berthSwitch.harborId;
+  const { data: harborData } = useQuery<HarborNameQuery, { id: string }>(
+    GET_HARBOR_NAME(application.berthSwitch.harborId)
+  );
+  const harborName = harborData?.harbor?.properties?.name ?? application.berthSwitch.harborId;
 
   const { data: reasonData } = useQuery<BerthSwitchReasonsQuery>(BERTH_SWITCH_REASONS_QUERY);
   const reasons = reasonData?.berthSwitchReasons ? reasonData.berthSwitchReasons.filter(isReason) : [];

--- a/src/features/berth/berthPage/berthLegend/applicationSelector/ApplicationSelector.tsx
+++ b/src/features/berth/berthPage/berthLegend/applicationSelector/ApplicationSelector.tsx
@@ -38,8 +38,8 @@ const ApplicationSelector = ({
               name="application-selector-radio"
               label={
                 <>
-                  <strong>{t('page.berth.exchange_application.new.title')}</strong>
-                  <p>{t('page.berth.exchange_application.new.info_text')}</p>
+                  <strong>{t('page.berth.switch_application.new.title')}</strong>
+                  <p>{t('page.berth.switch_application.new.info_text')}</p>
                 </>
               }
             />
@@ -47,15 +47,15 @@ const ApplicationSelector = ({
           <Col xs="12" md="6">
             <Input
               type="radio"
-              value={ApplicationOptions.ExchangeApplication}
-              checked={berthsApplicationType === ApplicationOptions.ExchangeApplication}
+              value={ApplicationOptions.SwitchApplication}
+              checked={berthsApplicationType === ApplicationOptions.SwitchApplication}
               onChange={onSwitch}
-              id="vene-application-selector-exchange"
+              id="vene-application-selector-switch"
               name="application-selector-radio"
               label={
                 <>
-                  <strong>{t('page.berth.exchange_application.exchange.title')}</strong>
-                  <p>{t('page.berth.exchange_application.exchange.info_text')}</p>
+                  <strong>{t('page.berth.switch_application.switch.title')}</strong>
+                  <p>{t('page.berth.switch_application.switch.info_text')}</p>
                 </>
               }
             />
@@ -63,7 +63,7 @@ const ApplicationSelector = ({
         </Row>
       </Container>
 
-      {alertVisible && <Alert toggle={closeAlert} color="danger" messageId="page.berth.exchange_application.warning" />}
+      {alertVisible && <Alert toggle={closeAlert} color="danger" messageId="page.berth.switch_application.warning" />}
     </div>
   );
 };

--- a/src/features/berth/berthPage/berthLegend/applicationSelector/ApplicationSelectorContainer.tsx
+++ b/src/features/berth/berthPage/berthLegend/applicationSelector/ApplicationSelectorContainer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { EXCHANGE_APPLICATION_LIMIT } from '../../../../../common/utils/constants';
+import { SWITCH_APPLICATION_LIMIT } from '../../../../../common/utils/constants';
 import { switchApplication as switchApplicationAction } from '../../../../../redux/actions/ApplicationActions';
 import {
   resetBerthLimit as resetBerthLimitAction,
@@ -38,11 +38,11 @@ export const ApplicationSelectorContainer = ({
       setAlertVisible(false);
       switchApplication(e.currentTarget.value);
       resetBerthLimit();
-    } else if (selectedBerthCount > EXCHANGE_APPLICATION_LIMIT) {
+    } else if (selectedBerthCount > SWITCH_APPLICATION_LIMIT) {
       setAlertVisible(true);
     } else {
-      switchApplication(e.currentTarget.value as ApplicationOptions.ExchangeApplication);
-      setBerthLimit(EXCHANGE_APPLICATION_LIMIT);
+      switchApplication(e.currentTarget.value as ApplicationOptions.SwitchApplication);
+      setBerthLimit(SWITCH_APPLICATION_LIMIT);
     }
   };
 

--- a/src/features/berth/berthPage/berthLegend/applicationSelector/__tests__/ApplicationSelector.test.tsx
+++ b/src/features/berth/berthPage/berthLegend/applicationSelector/__tests__/ApplicationSelector.test.tsx
@@ -40,9 +40,9 @@ describe('forms/sections/ApplicationSelector', () => {
     expect((getByLabelText(/Vaihtohakemus/) as HTMLInputElement).checked).toBe(false);
   });
 
-  test('if berthsApplicationType is ExchangeApplication, show "exchange application" as checked', () => {
+  test('if berthsApplicationType is SwitchApplication, show "switch application" as checked', () => {
     const { getByLabelText } = renderComponent({
-      berthsApplicationType: ApplicationOptions.ExchangeApplication,
+      berthsApplicationType: ApplicationOptions.SwitchApplication,
     });
 
     expect((getByLabelText(/Uusi hakemus/) as HTMLInputElement).checked).toBe(false);
@@ -53,7 +53,7 @@ describe('forms/sections/ApplicationSelector', () => {
     let eventValue = null;
     const onSwitch = jest.fn((event) => (eventValue = event.target.value));
     const { getByLabelText } = renderComponent({
-      berthsApplicationType: ApplicationOptions.ExchangeApplication,
+      berthsApplicationType: ApplicationOptions.SwitchApplication,
       onSwitch: onSwitch,
     });
 
@@ -61,7 +61,7 @@ describe('forms/sections/ApplicationSelector', () => {
     expect(eventValue).toEqual(ApplicationOptions.NewApplication);
   });
 
-  test('clicking "exchange application" calls onSwitch expectedly', () => {
+  test('clicking "switch application" calls onSwitch expectedly', () => {
     let eventValue = null;
     const onSwitch = jest.fn((event) => (eventValue = event.target.value));
     const { getByLabelText } = renderComponent({
@@ -70,7 +70,7 @@ describe('forms/sections/ApplicationSelector', () => {
     });
 
     fireEvent.click(getByLabelText(/Vaihtohakemus/));
-    expect(eventValue).toEqual(ApplicationOptions.ExchangeApplication);
+    expect(eventValue).toEqual(ApplicationOptions.SwitchApplication);
   });
 
   test('if alertVisible is true, Alert should be shown', () => {

--- a/src/features/berth/berthPage/berthLegend/applicationSelector/__tests__/ApplicationSelectorContainer.test.tsx
+++ b/src/features/berth/berthPage/berthLegend/applicationSelector/__tests__/ApplicationSelectorContainer.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 
-import { EXCHANGE_APPLICATION_LIMIT } from '../../../../../../common/utils/constants';
+import { SWITCH_APPLICATION_LIMIT } from '../../../../../../common/utils/constants';
 import { ApplicationOptions } from '../../../../../../common/types/applicationType';
 import { ApplicationSelectorContainer, ApplicationSelectorContainerProps } from '../ApplicationSelectorContainer';
 import * as useAutoDismissAlert from '../useAutoDismissAlert';
@@ -28,7 +28,7 @@ describe('forms/sections/ApplicationSelectorContainer', () => {
 
     jest.spyOn(useAutoDismissAlert, 'default').mockImplementation(() => [false, setAlertVisible]);
     const { getByLabelText } = renderComponent({
-      berthsApplicationType: ApplicationOptions.ExchangeApplication,
+      berthsApplicationType: ApplicationOptions.SwitchApplication,
       resetBerthLimit: resetBerthLimit,
       switchApplication: switchApplication,
     });
@@ -39,14 +39,14 @@ describe('forms/sections/ApplicationSelectorContainer', () => {
     expect(setAlertVisible).toHaveBeenCalledWith(false);
   });
 
-  test('if switched to exchange application and over berth limit, should prevent switch and show alert', () => {
+  test('if switched to switch application and over berth limit, should prevent switch and show alert', () => {
     const switchApplication = jest.fn();
     const setAlertVisible = jest.fn();
 
     jest.spyOn(useAutoDismissAlert, 'default').mockImplementation(() => [false, setAlertVisible]);
     const { getByLabelText } = renderComponent({
       berthsApplicationType: ApplicationOptions.NewApplication,
-      selectedBerthCount: EXCHANGE_APPLICATION_LIMIT + 1,
+      selectedBerthCount: SWITCH_APPLICATION_LIMIT + 1,
       switchApplication: switchApplication,
     });
 
@@ -55,7 +55,7 @@ describe('forms/sections/ApplicationSelectorContainer', () => {
     expect(setAlertVisible).toHaveBeenCalledWith(true);
   });
 
-  test('if switched to exchange application, should set berth limit', () => {
+  test('if switched to switch application, should set berth limit', () => {
     const setBerthLimit = jest.fn();
     const switchApplication = jest.fn();
     const setAlertVisible = jest.fn();
@@ -68,7 +68,7 @@ describe('forms/sections/ApplicationSelectorContainer', () => {
     });
 
     fireEvent.click(getByLabelText(/Vaihtohakemus/));
-    expect(setBerthLimit).toHaveBeenCalledWith(EXCHANGE_APPLICATION_LIMIT);
-    expect(switchApplication).toHaveBeenCalledWith(ApplicationOptions.ExchangeApplication);
+    expect(setBerthLimit).toHaveBeenCalledWith(SWITCH_APPLICATION_LIMIT);
+    expect(switchApplication).toHaveBeenCalledWith(ApplicationOptions.SwitchApplication);
   });
 });

--- a/src/features/berth/selectedBerthPage/SelectedBerthPage.tsx
+++ b/src/features/berth/selectedBerthPage/SelectedBerthPage.tsx
@@ -5,7 +5,7 @@ import { Alert, Button, Col, Container, Form as BTForm, Row } from 'reactstrap';
 
 import Icon, { IconNames } from '../../../common/icon/Icon';
 import LocalizedLink from '../../../common/localizedLink/LocalizedLink';
-import ExchangeApplication from './exchangeApplication/ExchangeApplicationContainer';
+import SwitchApplication from './switchApplication/SwitchApplicationContainer';
 import NewApplication from './newApplication/NewApplication';
 import Layout from '../../../common/layout/Layout';
 import SelectionPageLegend from '../../../common/selectionPageLegend/SelectionPageLegend';
@@ -38,7 +38,7 @@ export type Props = {
   moveDown(id: string): void;
   moveToForm(): void;
   moveUp(id: string): void;
-  submitExchangeForm?(values: BerthFormValues): void;
+  submitSwitchForm?(values: BerthFormValues): void;
 };
 
 const SelectedBerthPage = ({
@@ -55,15 +55,15 @@ const SelectedBerthPage = ({
   moveUp,
   selectedBerths,
   steps,
-  submitExchangeForm,
+  submitSwitchForm,
   validSelection,
 }: Props) => {
   const { t } = useTranslation();
   useLayoutEffect(() => window.scrollTo(0, 0), []);
 
   const handleSubmitApplication = (values: BerthFormValues) => {
-    if (submitExchangeForm) {
-      submitExchangeForm(values);
+    if (submitSwitchForm) {
+      submitSwitchForm(values);
     }
     moveToForm();
   };
@@ -84,7 +84,7 @@ const SelectedBerthPage = ({
                     (berthsApplicationType === ApplicationOptions.NewApplication ? (
                       <NewApplication />
                     ) : (
-                      <ExchangeApplication berths={berths} />
+                      <SwitchApplication berths={berths} />
                     ))}
 
                   <h3>{t('page.berth.selected.title')}</h3>

--- a/src/features/berth/selectedBerthPage/SelectedBerthPageContainer.tsx
+++ b/src/features/berth/selectedBerthPage/SelectedBerthPageContainer.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { compose } from 'recompose';
 import { useQuery } from 'react-apollo';
 
-import { submitApplicationForm as submitExchangeForm } from '../../../redux/actions/ApplicationActions';
+import { submitApplicationForm as submitSwitchForm } from '../../../redux/actions/ApplicationActions';
 import { deselectBerth, moveDown, moveUp } from '../../../redux/actions/BerthActions';
 import { BoatTypesBerthsQuery } from '../../__generated__/BoatTypesBerthsQuery';
 import { getResources, getSelectedResources } from '../../../common/utils/applicationUtils';
@@ -24,7 +24,7 @@ interface Props {
   values: BerthFormValues;
   berthsApplicationType: string;
   initialValues: BerthFormValues;
-  submitExchangeForm(values: BerthFormValues): void;
+  submitSwitchForm(values: BerthFormValues): void;
   deselectBerth(id: string): void;
   moveUp(id: string): void;
   moveDown(id: string): void;
@@ -118,7 +118,7 @@ export default compose<Props, Props>(
       deselectBerth,
       moveUp,
       moveDown,
-      submitExchangeForm,
+      submitSwitchForm,
     }
   )
 )(UnconnectedSelectedBerthPage);

--- a/src/features/berth/selectedBerthPage/__tests__/SelectedBerthPage.test.tsx
+++ b/src/features/berth/selectedBerthPage/__tests__/SelectedBerthPage.test.tsx
@@ -14,7 +14,7 @@ describe('pages/BerthPage/SelectedBerthPage', () => {
     moveUp: jest.fn(),
     moveDown: jest.fn(),
     berthsApplicationType: ApplicationOptions.NewApplication,
-    submitExchangeForm: jest.fn(),
+    submitSwitchForm: jest.fn(),
     values: berthValues,
     moveToForm: jest.fn(),
     handlePrevious: jest.fn(),

--- a/src/features/berth/selectedBerthPage/newApplication/NewApplication.tsx
+++ b/src/features/berth/selectedBerthPage/newApplication/NewApplication.tsx
@@ -10,8 +10,8 @@ const NewApplication = () => {
     <Container className="vene-new-application">
       <Row>
         <Col sm={10}>
-          <h3 className="vene-new-application__heading">{t('page.berth.exchange_application.new.title')}</h3>
-          <span>{t('page.berth.exchange_application.new.info_text')}</span>
+          <h3 className="vene-new-application__heading">{t('page.berth.switch_application.new.title')}</h3>
+          <span>{t('page.berth.switch_application.new.info_text')}</span>
         </Col>
       </Row>
     </Container>

--- a/src/features/berth/selectedBerthPage/switchApplication/SwitchApplication.tsx
+++ b/src/features/berth/selectedBerthPage/switchApplication/SwitchApplication.tsx
@@ -6,31 +6,29 @@ import { Berths } from '../../types';
 import { Select, Text } from '../../../../common/fields/Fields';
 import { BerthSwitchReasonsQuery_berthSwitchReasons } from '../../../__generated__/BerthSwitchReasonsQuery';
 
-import './exchangeApplication.scss';
+import './switchApplication.scss';
 
-export interface ExchangeApplicationProps {
+export interface SwitchApplicationProps {
   berths: Berths;
   reasons?: BerthSwitchReasonsQuery_berthSwitchReasons[];
 }
 
-const ExchangeApplication = ({ berths, reasons }: ExchangeApplicationProps) => {
+const SwitchApplication = ({ berths, reasons }: SwitchApplicationProps) => {
   const { t } = useTranslation();
   return (
-    <Container className="vene-exchange-application">
+    <Container className="vene-switch-application">
       <Row>
         <Col>
-          <h3 className="vene-exchange-application__heading">
-            {t('page.berth.exchange_application.current_berth.title')}
-          </h3>
-          <p className="vene-exchange-application__description">
-            {t('page.berth.exchange_application.current_berth.info_text')}
+          <h3 className="vene-switch-application__heading">{t('page.berth.switch_application.current_berth.title')}</h3>
+          <p className="vene-switch-application__description">
+            {t('page.berth.switch_application.current_berth.info_text')}
           </p>
         </Col>
       </Row>
 
       <Row>
         <Col>
-          <Select name="harborId" label="page.berth.exchange_application.form.current_harbour_area.label" required>
+          <Select name="harborId" label="page.berth.switch_application.form.current_harbour_area.label" required>
             <option />
             {berths.size &&
               berths.map((berth) => (
@@ -46,8 +44,8 @@ const ExchangeApplication = ({ berths, reasons }: ExchangeApplicationProps) => {
         <Col sm={6}>
           <Text
             name="pier"
-            label="page.berth.exchange_application.form.pier.title"
-            placeholder="page.berth.exchange_application.form.pier.placeholder"
+            label="page.berth.switch_application.form.pier.title"
+            placeholder="page.berth.switch_application.form.pier.placeholder"
           />
         </Col>
 
@@ -55,25 +53,23 @@ const ExchangeApplication = ({ berths, reasons }: ExchangeApplicationProps) => {
           <Text
             name="berthNumber"
             required
-            label="page.berth.exchange_application.form.berth.title"
-            placeholder="page.berth.exchange_application.form.berth.placeholder"
+            label="page.berth.switch_application.form.berth.title"
+            placeholder="page.berth.switch_application.form.berth.placeholder"
           />
         </Col>
       </Row>
 
       <Row>
         <Col>
-          <h3 className="vene-exchange-application__heading">{t('page.berth.exchange_application.reason.title')}</h3>
-          <p className="vene-exchange-application__description">
-            {t('page.berth.exchange_application.reason.info_text')}
-          </p>
+          <h3 className="vene-switch-application__heading">{t('page.berth.switch_application.reason.title')}</h3>
+          <p className="vene-switch-application__description">{t('page.berth.switch_application.reason.info_text')}</p>
         </Col>
       </Row>
 
       <Row>
         <Col>
           <Select name="reason">
-            <option value="">{t('page.berth.exchange_application.reason.default')}</option>
+            <option value="">{t('page.berth.switch_application.reason.default')}</option>
             {reasons &&
               reasons.map((reason) => (
                 <option key={reason.id} value={reason.id}>
@@ -87,4 +83,4 @@ const ExchangeApplication = ({ berths, reasons }: ExchangeApplicationProps) => {
   );
 };
 
-export default ExchangeApplication;
+export default SwitchApplication;

--- a/src/features/berth/selectedBerthPage/switchApplication/SwitchApplication.tsx
+++ b/src/features/berth/selectedBerthPage/switchApplication/SwitchApplication.tsx
@@ -31,11 +31,13 @@ const SwitchApplication = ({ berths, reasons }: SwitchApplicationProps) => {
           <Select name="harborId" label="page.berth.switch_application.form.current_harbour_area.label" required>
             <option />
             {berths.size &&
-              berths.map((berth) => (
-                <option key={berth.id} value={berth.id}>
-                  {berth.name}
-                </option>
-              ))}
+              berths
+                .sort((a, b) => ((a.name || '') > (b.name || '') ? 1 : -1))
+                .map((berth) => (
+                  <option key={berth.id} value={berth.id}>
+                    {berth.name}
+                  </option>
+                ))}
           </Select>
         </Col>
       </Row>

--- a/src/features/berth/selectedBerthPage/switchApplication/SwitchApplicationContainer.tsx
+++ b/src/features/berth/selectedBerthPage/switchApplication/SwitchApplicationContainer.tsx
@@ -6,17 +6,17 @@ import {
   BerthSwitchReasonsQuery_berthSwitchReasons as Reason,
 } from '../../../__generated__/BerthSwitchReasonsQuery';
 import { BERTH_SWITCH_REASONS_QUERY } from '../../../queries';
-import ExchangeApplication, { ExchangeApplicationProps } from './ExchangeApplication';
+import SwitchApplication, { SwitchApplicationProps } from './SwitchApplication';
 
-type Props = Omit<ExchangeApplicationProps, 'reasons'>;
+type Props = Omit<SwitchApplicationProps, 'reasons'>;
 
 const isReason = (reason: Reason | null): reason is Reason => reason !== null;
 
-const ExchangeApplicationContainer = (props: Props) => {
+const SwitchApplicationContainer = (props: Props) => {
   const { data } = useQuery<BerthSwitchReasonsQuery>(BERTH_SWITCH_REASONS_QUERY);
   const reasons = data?.berthSwitchReasons ? data.berthSwitchReasons.filter(isReason) : [];
 
-  return <ExchangeApplication reasons={reasons} {...props} />;
+  return <SwitchApplication reasons={reasons} {...props} />;
 };
 
-export default ExchangeApplicationContainer;
+export default SwitchApplicationContainer;

--- a/src/features/berth/selectedBerthPage/switchApplication/__tests__/SwitchApplication.test.tsx
+++ b/src/features/berth/selectedBerthPage/switchApplication/__tests__/SwitchApplication.test.tsx
@@ -3,14 +3,14 @@ import React from 'react';
 
 import { berths } from '../../../../../__fixtures__/berthFixture';
 import { Select, Text } from '../../../../../common/fields/Fields';
-import ExchangeApplication, { ExchangeApplicationProps } from '../ExchangeApplication';
+import SwitchApplication, { SwitchApplicationProps } from '../SwitchApplication';
 
-describe('fragments/ExchangeApplication', () => {
+describe('fragments/SwitchApplication', () => {
   const mockHarbor = berths;
 
-  const getWrapper = (props?: Partial<ExchangeApplicationProps>) =>
+  const getWrapper = (props?: Partial<SwitchApplicationProps>) =>
     shallow(
-      <ExchangeApplication
+      <SwitchApplication
         reasons={[
           { __typename: 'BerthSwitchReasonType', id: '1', title: 'foo' },
           { __typename: 'BerthSwitchReasonType', id: '2', title: 'bar' },

--- a/src/features/berth/selectedBerthPage/switchApplication/switchApplication.scss
+++ b/src/features/berth/selectedBerthPage/switchApplication/switchApplication.scss
@@ -1,7 +1,7 @@
 @import 'helsinki/colors';
 @import 'styles/variables';
 
-.vene-exchange-application {
+.vene-switch-application {
   background-color: $hel-light;
   padding: $spacing-02 $spacing-03 $spacing-01 $spacing-01-50;
 

--- a/src/features/profile/customerBerths/properties/Property.tsx
+++ b/src/features/profile/customerBerths/properties/Property.tsx
@@ -12,9 +12,9 @@ export interface PropertyProps {
 const Property = ({ icon, labelKey }: PropertyProps) => {
   const { t } = useTranslation();
   return (
-    <div className="vene-property">
-      <Icon name={icon} className="vene-property__icon" />
-      <p className="vene-property__label">{t(labelKey)}</p>
+    <div className="vene-berth-property">
+      <Icon name={icon} className="vene-berth-property__icon" />
+      <p className="vene-berth-property__label">{t(labelKey)}</p>
     </div>
   );
 };

--- a/src/features/profile/customerBerths/properties/property.scss
+++ b/src/features/profile/customerBerths/properties/property.scss
@@ -1,7 +1,7 @@
 @import 'helsinki/colors';
 @import 'styles/variables';
 
-.vene-property {
+.vene-berth-property {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/features/winterStorage/selectedAreaPage/SelectedAreaPage.tsx
+++ b/src/features/winterStorage/selectedAreaPage/SelectedAreaPage.tsx
@@ -31,7 +31,7 @@ export type Props = {
   moveDown(id: string): void;
   moveToForm(): void;
   moveUp(id: string): void;
-  submitExchangeForm?(values: WinterFormValues): void;
+  submitSwitchForm?(values: WinterFormValues): void;
 };
 
 const SelectedAreaPage = ({
@@ -46,15 +46,15 @@ const SelectedAreaPage = ({
   moveUp,
   selectedAreas,
   steps,
-  submitExchangeForm,
+  submitSwitchForm,
   validSelection,
 }: Props) => {
   const { t } = useTranslation();
   useLayoutEffect(() => window.scrollTo(0, 0), []);
 
   const handleSubmitApplication = (values: WinterFormValues) => {
-    if (submitExchangeForm) {
-      submitExchangeForm(values);
+    if (submitSwitchForm) {
+      submitSwitchForm(values);
     }
     moveToForm();
   };

--- a/src/features/winterStorage/selectedAreaPage/__tests__/SelectedAreaPage.test.tsx
+++ b/src/features/winterStorage/selectedAreaPage/__tests__/SelectedAreaPage.test.tsx
@@ -12,7 +12,7 @@ describe('pages/BerthPage/SelectedAreaPage', () => {
     deselectArea: jest.fn(),
     moveUp: jest.fn(),
     moveDown: jest.fn(),
-    submitExchangeForm: jest.fn(),
+    submitSwitchForm: jest.fn(),
     values: winterValues,
     moveToForm: jest.fn(),
     handlePrevious: jest.fn(),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -517,14 +517,14 @@
       "title": "Thank you, your application has been sent successfully!"
     },
     "berth": {
-      "exchange_application": {
+      "switch_application": {
         "current_berth": {
-          "info_text": "Please provide the details of your current berth for the exchange application. ",
+          "info_text": "Please provide the details of your current berth for the switch application. ",
           "title": "Information on your current berth"
         },
-        "exchange": {
+        "switch": {
           "info_text": "Exchanging a berth at a City of Helsinki harbour",
-          "title": "Exchange application"
+          "title": "Switch application"
         },
         "form": {
           "berth": {
@@ -548,7 +548,7 @@
           "info_text": "You can select a special request concerning the type of the new berth from the list. Please note, however, that if you select a special request, you will only be offered a berth when a berth meeting your request becomes available.",
           "title": "Special request for a new berth"
         },
-        "warning": "You can select up to five harbours for your exchange application. Please remove excess selections and change the application type again."
+        "warning": "You can select up to five harbours for your switch application. Please remove excess selections and change the application type again."
       },
       "selected": {
         "alert": {
@@ -623,7 +623,7 @@
       "card": {
         "berths": {
           "button_label": "Browse and search for boat berths",
-          "description": "Browse the City of Helsinki’s boat harbours. You can submit a new boat berth application or apply to exchange your current boat berth for another one.",
+          "description": "Browse the City of Helsinki’s boat harbours. You can submit a new boat berth application or apply to switch your current boat berth for another one.",
           "title": "Boat berth search"
         },
         "instructions": "Additional information and instructions (hel.fi)",
@@ -640,7 +640,7 @@
         }
       },
       "description": {
-        "body": "Browse the City of Helsinki’s boat harbours. You can submit a new boat berth application or apply to exchange your current boat berth for another one.",
+        "body": "Browse the City of Helsinki’s boat harbours. You can submit a new boat berth application or apply to switch your current boat berth for another one.",
         "heading": "Boat berths and the winter storage of boats"
       },
       "title": "Boat berths"
@@ -763,7 +763,7 @@
           "harbor_map": "Harbour map (PDF)",
           "harbor_website": "Website",
           "heading": "Offer for berth. If you wish to accept it, please pay the invoice before the due date {{date}}.",
-          "info_text": "The invoice will be deleted in both cases (accept/decline). If you wish to have a different berth, accept the offer and make an exchange application. Exchange applications are processed yearly before new applications.",
+          "info_text": "The invoice will be deleted in both cases (accept/decline). If you wish to have a different berth, accept the offer and make an switch application. Switch applications are processed yearly before new applications.",
           "net_price": "Net price",
           "keep_application_active": "I want the application to remain valid if there are no free berths for this sailing season",
           "reject_offer": "Decline offer",
@@ -927,7 +927,7 @@
       "send_application": "Summary",
       "title": {
         "berths": {
-          "exchange": "Exchange application",
+          "switch": "Switch application",
           "new": "New application"
         },
         "winter_storage": "Winter storage application"

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -518,12 +518,12 @@
       "title": "Kiitos, hakemuksesi on lähetetty!"
     },
     "berth": {
-      "exchange_application": {
+      "switch_application": {
         "current_berth": {
           "info_text": "Vaihtohakemusta varten syötä nykyisen venepaikan tiedot. ",
           "title": "Nykyisen paikan tiedot"
         },
-        "exchange": {
+        "switch": {
           "info_text": "Helsingin kaupungin satamassa olevan venepaikan vaihto",
           "title": "Vaihtohakemus"
         },
@@ -928,7 +928,7 @@
       "send_application": "Yhteenveto",
       "title": {
         "berths": {
-          "exchange": "Vaihtohakemus",
+          "switch": "Vaihtohakemus",
           "new": "Uusi hakemus"
         },
         "winter_storage": "Talvisäilytyspaikan hakemus"

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -517,12 +517,12 @@
       "title": "Tack, din ansökan har skickats!"
     },
     "berth": {
-      "exchange_application": {
+      "switch_application": {
         "current_berth": {
           "info_text": "Fyll i uppgifterna om den nuvarande platsen i ansökan om byte. ",
           "title": "Uppgifter om den nuvarande platsen"
         },
-        "exchange": {
+        "switch": {
           "info_text": "Byte av båtplats i någon av Helsingfors stads hamnar",
           "title": "Ansökan om byte"
         },
@@ -927,7 +927,7 @@
       "send_application": "Sammanfattning",
       "title": {
         "berths": {
-          "exchange": "Ansökan om byte",
+          "switch": "Ansökan om byte",
           "new": "Ny ansökan"
         },
         "winter_storage": "Ansökan om vinteruppläggningsplats"


### PR DESCRIPTION
## Description :sparkles:

* Replace term "exchange" with "switch"
* Fix clashing property component styles (VEN-1290)
* Sort harbor options on SwitchApplication page by name
* Correct OldBerthInfo harbor name

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1204](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1204): FE - Customer UI page to accept/reject switch offer
* [VEN-1290](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1290): FE - Padding on service icons on Customer UI

## Testing :alembic:

### Manual testing :construction_worker_man:
* Properties should render correctly
* Harbor options for old harbors should be sorted by name
* Previous harbor name should be shown correctly (instead of an ID)
