### PR TITLE
VEN-1294| Support WS place info on Payment and Contract pages

### DIFF
--- a/src/__generated__/globalTypes.ts
+++ b/src/__generated__/globalTypes.ts
@@ -7,6 +7,9 @@
 // START Enums and Input Objects
 //==============================================================
 
+/**
+ * An enumeration.
+ */
 export enum OrderStatus {
   CANCELLED = "CANCELLED",
   DRAFTED = "DRAFTED",
@@ -19,6 +22,9 @@ export enum OrderStatus {
   REJECTED = "REJECTED",
 }
 
+/**
+ * An enumeration.
+ */
 export enum OrderTypeEnum {
   ADDITIONAL_PRODUCT = "ADDITIONAL_PRODUCT",
   BERTH = "BERTH",
@@ -26,6 +32,9 @@ export enum OrderTypeEnum {
   WINTER_STORAGE = "WINTER_STORAGE",
 }
 
+/**
+ * An enumeration.
+ */
 export enum WinterStorageMethod {
   ON_TRAILER = "ON_TRAILER",
   ON_TRESTLES = "ON_TRESTLES",

--- a/src/features/__generated__/AcceptBerthSwitchOffer.ts
+++ b/src/features/__generated__/AcceptBerthSwitchOffer.ts
@@ -15,6 +15,21 @@ export interface AcceptBerthSwitchOffer_acceptBerthSwitchOffer {
 }
 
 export interface AcceptBerthSwitchOffer {
+  /**
+   * Accepts or rejects an offer for a berth switch application.
+   * 
+   * If the offer is accepted, it will terminate the old lease and create a new lease with the new berth.
+   * 
+   * If the offer is rejected, nothing is created and the related lease stays as is.
+   * 
+   * Errors:
+   * 
+   * **Requires permissions** to add and change berth leases and to change berth switch offers.
+   * 
+   * Errors:
+   * * The passed berth switch offer ID doesn't exist
+   * * The related lease must be in `PAID` status
+   */
   acceptBerthSwitchOffer: AcceptBerthSwitchOffer_acceptBerthSwitchOffer | null;
 }
 

--- a/src/features/__generated__/BerthQuery.ts
+++ b/src/features/__generated__/BerthQuery.ts
@@ -14,29 +14,44 @@ export interface BerthQuery_berth_pier_properties_harbor_properties {
 
 export interface BerthQuery_berth_pier_properties_harbor {
   __typename: "HarborNode";
+  /**
+   * The ID of the object.
+   */
   id: string;
   properties: BerthQuery_berth_pier_properties_harbor_properties | null;
 }
 
 export interface BerthQuery_berth_pier_properties {
   __typename: "PierProperties";
+  /**
+   * Laiturin/osa-alueen tunnus
+   */
   identifier: string;
   harbor: BerthQuery_berth_pier_properties_harbor;
 }
 
 export interface BerthQuery_berth_pier {
   __typename: "PierNode";
+  /**
+   * The ID of the object.
+   */
   id: string;
   properties: BerthQuery_berth_pier_properties | null;
 }
 
 export interface BerthQuery_berth {
   __typename: "BerthNode";
+  /**
+   * The ID of the object.
+   */
   id: string;
   number: string;
   pier: BerthQuery_berth_pier;
 }
 
 export interface BerthQuery {
+  /**
+   * The ID of the object
+   */
   berth: BerthQuery_berth | null;
 }

--- a/src/features/__generated__/HarborPiersQuery.ts
+++ b/src/features/__generated__/HarborPiersQuery.ts
@@ -9,44 +9,74 @@
 
 export interface HarborPiersQuery_harbor_properties_piers_edges_node_properties_berths_edges_node {
   __typename: "BerthNode";
+  /**
+   * The ID of the object.
+   */
   id: string;
   number: string;
 }
 
 export interface HarborPiersQuery_harbor_properties_piers_edges_node_properties_berths_edges {
   __typename: "BerthNodeEdge";
+  /**
+   * The item at the end of the edge
+   */
   node: HarborPiersQuery_harbor_properties_piers_edges_node_properties_berths_edges_node | null;
 }
 
 export interface HarborPiersQuery_harbor_properties_piers_edges_node_properties_berths {
   __typename: "BerthNodeConnection";
+  /**
+   * Contains the nodes in this connection.
+   */
   edges: (HarborPiersQuery_harbor_properties_piers_edges_node_properties_berths_edges | null)[];
 }
 
 export interface HarborPiersQuery_harbor_properties_piers_edges_node_properties {
   __typename: "PierProperties";
+  /**
+   * Laiturin/osa-alueen tunnus
+   */
   identifier: string;
   berths: HarborPiersQuery_harbor_properties_piers_edges_node_properties_berths;
 }
 
 export interface HarborPiersQuery_harbor_properties_piers_edges_node {
   __typename: "PierNode";
+  /**
+   * The ID of the object.
+   */
   id: string;
   properties: HarborPiersQuery_harbor_properties_piers_edges_node_properties | null;
 }
 
 export interface HarborPiersQuery_harbor_properties_piers_edges {
   __typename: "PierNodeEdge";
+  /**
+   * The item at the end of the edge
+   */
   node: HarborPiersQuery_harbor_properties_piers_edges_node | null;
 }
 
 export interface HarborPiersQuery_harbor_properties_piers {
   __typename: "PierNodeConnection";
+  /**
+   * Contains the nodes in this connection.
+   */
   edges: (HarborPiersQuery_harbor_properties_piers_edges | null)[];
 }
 
 export interface HarborPiersQuery_harbor_properties {
   __typename: "HarborProperties";
+  /**
+   * To filter the piers suitable for an application, you can use the `forApplication` argument. 
+   * 
+   * **Requires permissions** to access applications.
+   * 
+   * Errors:
+   * * Filter `forApplication` with a user without enough permissions
+   *  * Filter `forApplication` combined with either dimension (width, length) filter
+   */
   piers: HarborPiersQuery_harbor_properties_piers | null;
 }
 
@@ -56,6 +86,9 @@ export interface HarborPiersQuery_harbor {
 }
 
 export interface HarborPiersQuery {
+  /**
+   * The ID of the object
+   */
   harbor: HarborPiersQuery_harbor | null;
 }
 

--- a/src/features/__generated__/HarborsQuery.ts
+++ b/src/features/__generated__/HarborsQuery.ts
@@ -46,6 +46,9 @@ export interface HarborsQuery_harbors_edges_node_properties {
   name: string | null;
   numberOfPlaces: number;
   phone: string;
+  /**
+   * Tunnus palvelukarttajärjestelmässä
+   */
   servicemapId: string | null;
   streetAddress: string | null;
   suitableBoatTypes: (HarborsQuery_harbors_edges_node_properties_suitableBoatTypes | null)[];
@@ -57,6 +60,9 @@ export interface HarborsQuery_harbors_edges_node_properties {
 
 export interface HarborsQuery_harbors_edges_node {
   __typename: "HarborNode";
+  /**
+   * The ID of the object.
+   */
   id: string;
   geometry: HarborsQuery_harbors_edges_node_geometry | null;
   properties: HarborsQuery_harbors_edges_node_properties | null;
@@ -64,11 +70,17 @@ export interface HarborsQuery_harbors_edges_node {
 
 export interface HarborsQuery_harbors_edges {
   __typename: "HarborNodeEdge";
+  /**
+   * The item at the end of the edge
+   */
   node: HarborsQuery_harbors_edges_node | null;
 }
 
 export interface HarborsQuery_harbors {
   __typename: "HarborNodeConnection";
+  /**
+   * Contains the nodes in this connection.
+   */
   edges: (HarborsQuery_harbors_edges | null)[];
 }
 

--- a/src/features/__generated__/OrderDetails.ts
+++ b/src/features/__generated__/OrderDetails.ts
@@ -13,9 +13,9 @@ export interface OrderDetails_orderDetails {
   __typename: "OrderDetailsType";
   orderType: OrderTypeEnum;
   status: OrderStatus;
-  harbor: string;
-  pier: string;
-  berth: string;
+  place: string | null;
+  section: string | null;
+  area: string | null;
   isApplicationOrder: boolean;
 }
 

--- a/src/features/__generated__/SubmitWinterStorage.ts
+++ b/src/features/__generated__/SubmitWinterStorage.ts
@@ -11,6 +11,9 @@ import { CreateWinterStorageApplicationMutationInput } from "./../../__generated
 
 export interface SubmitWinterStorage_createWinterStorageApplication_winterStorageApplication {
   __typename: "WinterStorageApplicationNode";
+  /**
+   * The ID of the object.
+   */
   id: string;
 }
 

--- a/src/features/__generated__/UnmarkedWinterAreasQuery.ts
+++ b/src/features/__generated__/UnmarkedWinterAreasQuery.ts
@@ -21,17 +21,26 @@ export interface UnmarkedWinterAreasQuery_winterStorageAreas_edges_node_properti
 
 export interface UnmarkedWinterAreasQuery_winterStorageAreas_edges_node {
   __typename: "WinterStorageAreaNode";
+  /**
+   * The ID of the object.
+   */
   id: string;
   properties: UnmarkedWinterAreasQuery_winterStorageAreas_edges_node_properties | null;
 }
 
 export interface UnmarkedWinterAreasQuery_winterStorageAreas_edges {
   __typename: "WinterStorageAreaNodeEdge";
+  /**
+   * The item at the end of the edge
+   */
   node: UnmarkedWinterAreasQuery_winterStorageAreas_edges_node | null;
 }
 
 export interface UnmarkedWinterAreasQuery_winterStorageAreas {
   __typename: "WinterStorageAreaNodeConnection";
+  /**
+   * Contains the nodes in this connection.
+   */
   edges: (UnmarkedWinterAreasQuery_winterStorageAreas_edges | null)[];
 }
 

--- a/src/features/__generated__/WinterAreasQuery.ts
+++ b/src/features/__generated__/WinterAreasQuery.ts
@@ -36,6 +36,9 @@ export interface WinterAreasQuery_winterStorageAreas_edges_node_properties {
   maxWidth: number | null;
   municipality: string | null;
   name: string | null;
+  /**
+   * Tunnus palvelukarttajärjestelmässä
+   */
   servicemapId: string | null;
   streetAddress: string | null;
   wwwUrl: string;
@@ -50,6 +53,9 @@ export interface WinterAreasQuery_winterStorageAreas_edges_node_properties {
 
 export interface WinterAreasQuery_winterStorageAreas_edges_node {
   __typename: "WinterStorageAreaNode";
+  /**
+   * The ID of the object.
+   */
   id: string;
   geometry: WinterAreasQuery_winterStorageAreas_edges_node_geometry | null;
   properties: WinterAreasQuery_winterStorageAreas_edges_node_properties | null;
@@ -57,11 +63,17 @@ export interface WinterAreasQuery_winterStorageAreas_edges_node {
 
 export interface WinterAreasQuery_winterStorageAreas_edges {
   __typename: "WinterStorageAreaNodeEdge";
+  /**
+   * The item at the end of the edge
+   */
   node: WinterAreasQuery_winterStorageAreas_edges_node | null;
 }
 
 export interface WinterAreasQuery_winterStorageAreas {
   __typename: "WinterStorageAreaNodeConnection";
+  /**
+   * Contains the nodes in this connection.
+   */
   edges: (WinterAreasQuery_winterStorageAreas_edges | null)[];
 }
 

--- a/src/features/payment/berthInfo/BerthInfo.tsx
+++ b/src/features/payment/berthInfo/BerthInfo.tsx
@@ -5,9 +5,9 @@ import LabelValuePair from '../../../common/labelValuePair/LabelValuePair';
 import './berthInfo.scss';
 
 export interface BerthInfoProps {
-  harbor: string | undefined;
-  pier: string | undefined;
-  berth: string | undefined;
+  harbor: string | null | undefined;
+  pier: string | null | undefined;
+  berth: string | null | undefined;
 }
 
 const BerthInfo = ({ harbor, pier, berth }: BerthInfoProps) => {

--- a/src/features/payment/paymentPage/ContractPage.tsx
+++ b/src/features/payment/paymentPage/ContractPage.tsx
@@ -8,21 +8,16 @@ import { Checkbox } from '../../../common/fields/Fields';
 import { ContractAuthMethods_contractAuthMethods as ContractAuthMethods } from '../../__generated__/ContractAuthMethods';
 import Form from '../../../common/form/Form';
 import AuthButton from './authButton/AuthButton';
-import BerthInfo from '../berthInfo/BerthInfo';
 
 export interface Props {
-  placeDetails: {
-    harbor: string | undefined;
-    pier: string | undefined;
-    berth: string | undefined;
-  };
   orderNumber: string;
+  orderProductDetails: React.ReactNode;
   contractAuthMethods: ContractAuthMethods[];
   handleSign: (authMethod: string) => void;
   handleTerminate: () => void;
 }
 
-const PaymentPage = ({ contractAuthMethods, placeDetails, orderNumber, handleSign, handleTerminate }: Props) => {
+const PaymentPage = ({ contractAuthMethods, orderProductDetails, orderNumber, handleSign, handleTerminate }: Props) => {
   const { t } = useTranslation();
   const [termsOpened, setTermsOpened] = useState<boolean>(false);
   const [termsAccepted, setTermsAccepted] = useState<boolean>(false);
@@ -49,7 +44,7 @@ const PaymentPage = ({ contractAuthMethods, placeDetails, orderNumber, handleSig
         </div>
         <div className="vene-payment-page__content-container">
           <div className="vene-payment-page__content vene-payment-page__accept-terms-content">
-            <BerthInfo {...placeDetails} />
+            {orderProductDetails}
             <div>
               <h3 className="vene-payment-page__subheading">{t('page.contract.read_and_approve')}</h3>
               <p className="vene-payment-page__notice">{t('page.contract.terms_notice')}</p>

--- a/src/features/payment/paymentPage/PaymentPage.tsx
+++ b/src/features/payment/paymentPage/PaymentPage.tsx
@@ -3,19 +3,14 @@ import { useTranslation } from 'react-i18next';
 import { Button } from 'reactstrap';
 
 import Layout from '../../../common/layout/Layout';
-import BerthInfo from '../berthInfo/BerthInfo';
 import './paymentPage.scss';
 
 interface Props {
-  placeDetails: {
-    harbor: string | undefined;
-    pier: string | undefined;
-    berth: string | undefined;
-  };
+  orderProductDetails: React.ReactNode;
   handlePay: () => void;
 }
 
-const PaymentPage = ({ placeDetails, handlePay }: Props) => {
+const PaymentPage = ({ orderProductDetails, handlePay }: Props) => {
   const { t } = useTranslation();
 
   return (
@@ -40,7 +35,7 @@ const PaymentPage = ({ placeDetails, handlePay }: Props) => {
         </div>
         <div className="vene-payment-page__content-container">
           <div className="vene-payment-page__content vene-payment-page__accept-terms-content">
-            <BerthInfo {...placeDetails} />
+            {orderProductDetails}
             <Button className="vene-payment-page__pay-button" color="secondary" onClick={handlePay}>
               {t('page.payment.pay')}
             </Button>

--- a/src/features/payment/paymentPage/PaymentPageContainer.tsx
+++ b/src/features/payment/paymentPage/PaymentPageContainer.tsx
@@ -19,6 +19,8 @@ import {
   OrderDetailsVariables,
 } from '../../__generated__/OrderDetails';
 import { FulfillContract, FulfillContractVariables } from '../../__generated__/FulfillContract';
+import BerthInfo from '../berthInfo/BerthInfo';
+import WinterStorageInfo from '../winterStorageInfo/WinterStorageInfo';
 
 interface Props {
   localePush: LocalePush;
@@ -84,9 +86,9 @@ const PaymentPageContainer = ({ localePush }: Props) => {
 
   return getPaymentPage(
     {
-      harbor: orderDetailsData.orderDetails?.harbor,
-      pier: orderDetailsData.orderDetails?.pier,
-      berth: orderDetailsData.orderDetails?.berth,
+      area: orderDetailsData.orderDetails?.area,
+      section: orderDetailsData.orderDetails?.section,
+      place: orderDetailsData.orderDetails?.place,
     },
     orderDetailsData?.orderDetails?.orderType,
     orderNumber,
@@ -101,9 +103,9 @@ const PaymentPageContainer = ({ localePush }: Props) => {
 
 export const getPaymentPage = (
   placeDetails: {
-    harbor: string | undefined;
-    pier: string | undefined;
-    berth: string | undefined;
+    area: string | null | undefined;
+    section: string | null | undefined;
+    place: string | null | undefined;
   },
   orderType: OrderTypeEnum | undefined,
   orderNumber: string,
@@ -118,10 +120,26 @@ export const getPaymentPage = (
     return <GeneralPaymentErrorPage />;
   }
 
+  let orderProductDetails: React.ReactNode = null;
+
+  switch (orderType) {
+    case OrderTypeEnum.BERTH:
+    case OrderTypeEnum.ADDITIONAL_PRODUCT:
+      orderProductDetails = (
+        <BerthInfo harbor={placeDetails.area} pier={placeDetails.section} berth={placeDetails.place} />
+      );
+      break;
+    case OrderTypeEnum.WINTER_STORAGE:
+      orderProductDetails = <WinterStorageInfo {...placeDetails} />;
+      break;
+    default:
+      break;
+  }
+
   if (contractSigned !== null && !contractSigned) {
     return (
       <ContractPage
-        placeDetails={placeDetails}
+        orderProductDetails={orderProductDetails}
         orderNumber={orderNumber}
         handleSign={signContract}
         handleTerminate={handleTerminate}
@@ -132,7 +150,7 @@ export const getPaymentPage = (
 
   switch (status) {
     case OrderStatus.OFFERED:
-      return <PaymentPage handlePay={confirmPayment} placeDetails={placeDetails} />;
+      return <PaymentPage handlePay={confirmPayment} orderProductDetails={orderProductDetails} />;
     case OrderStatus.PAID:
       return <AlreadyPaidPage isAdditionalProduct={orderType === OrderTypeEnum.ADDITIONAL_PRODUCT} />;
     case OrderStatus.EXPIRED:

--- a/src/features/payment/winterStorageInfo/WinterStorageInfo.tsx
+++ b/src/features/payment/winterStorageInfo/WinterStorageInfo.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import LabelValuePair from '../../../common/labelValuePair/LabelValuePair';
+import './winterStorageInfo.scss';
+
+export interface WinterStorageInfoProps {
+  area: string | null | undefined;
+  section: string | null | undefined;
+  place: string | null | undefined;
+}
+
+const WinterStorageInfo = ({ area, section, place }: WinterStorageInfoProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="vene-payment-winter-storage-info">
+      <h3 className="vene-payment-winter-storage-info__heading">{t('page.payment.winter_storage_information')}</h3>
+      <LabelValuePair label={t('common.area')} value={area} />
+      <LabelValuePair label={t('common.section')} value={section} />
+      <LabelValuePair label={t('common.place')} value={place} />
+    </div>
+  );
+};
+
+export default WinterStorageInfo;

--- a/src/features/payment/winterStorageInfo/winterStorageInfo.scss
+++ b/src/features/payment/winterStorageInfo/winterStorageInfo.scss
@@ -1,0 +1,7 @@
+@import 'helsinki/fonts';
+
+.vene-payment-winter-storage-info {
+  &__heading {
+    font-size: $font-size-lg;
+  }
+}

--- a/src/features/queries.ts
+++ b/src/features/queries.ts
@@ -208,9 +208,9 @@ export const GET_ORDER_DETAILS = gql`
     orderDetails(orderNumber: $orderNumber) {
       orderType
       status
-      harbor
-      pier
-      berth
+      place
+      section
+      area
       isApplicationOrder
     }
     contractSigned(orderNumber: $orderNumber) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "additional_services": "Additional services",
+    "area": "Area",
     "berth": "Berth",
     "cancelled": "Cancelled",
     "dinghy_place": "Dinghy place",
@@ -20,8 +21,10 @@
     "paid_manually": "Paid elsewhere",
     "parking_permit": "Parking permit",
     "pier": "Pier",
+    "place": "Place",
     "rejected": "Rejected",
     "season": "Season",
+    "section": "Section",
     "sent": "Sent",
     "storage_on_ice": "Storage on ice",
     "total": "Total",
@@ -713,6 +716,7 @@
     },
     "payment": {
       "berth_information": "Berth",
+      "winter_storage_information": "Winter storage place",
       "title": "Paying the invoice",
       "info": "You can proceed to pay your invoice.",
       "questions": "Questions and further information: ",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "additional_services": "Lisäpalvelut",
+    "area": "Alue",
     "berth": "Paikka",
     "cancelled": "Peruutettu",
     "dinghy_place": "Jollapaikka",
@@ -21,8 +22,10 @@
     "paid_manually": "Maksettu muualla",
     "parking_permit":"Pysäköintilupa",
     "pier": "Laituri",
+    "place": "Paikka",
     "rejected": "Hylätty",
     "season": "Sopimuskausi",
+    "section": "Osasto",
     "sent": "Lähetetty",
     "storage_on_ice": "Jäissä säilytys",
     "total": "Yhteensä",
@@ -714,6 +717,7 @@
     },
     "payment": {
       "berth_information": "Venepaikan tiedot",
+      "winter_storage_information": "Talvisäilytyspaikan tiedot",
       "title": "Laskun maksaminen",
       "info": "Voit siirtyä maksamaan laskusi.",
       "questions": "Kysymykset ja lisätiedot: ",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "additional_services": "Ytterligare tjänster",
+    "area": "Området",
     "berth": "Båtplatsen",
     "cancelled": "Annullerat",
     "dinghy_place": "Jolleplats",
@@ -20,8 +21,10 @@
     "paid_manually": "Betalas någon annanstans",
     "parking_permit": "Parkeringstillstånd",
     "pier": "Kaj",
+    "place": "Plats",
     "rejected": "Avvisade",
     "season": "Avtalsperiod",
+    "section": "Sektion",
     "sent": "Skickas",
     "storage_on_ice": "Förvaring på is",
     "total": "Totalt",
@@ -713,6 +716,7 @@
     },
     "payment": {
       "berth_information": "Båtplatsen",
+      "winter_storage_information": "Vinteruppläggningsplats",
       "title": "Betalning av fakturan",
       "info": "Du kan gå till att betala din faktura.",
       "questions": "Frågor och mer information: ",


### PR DESCRIPTION
## Description :sparkles:
- Added a new component for displaying WS areas info
- Pass product as a prop to Payment and Contract pages

## Issues :bug:

### Closes :no_good_woman:
[VEN-1294](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1294): add ws place/section/area information to the customer UI payment page

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:
- When getting an offer, go to the payment link you received
- The payment page should show the information about the product you're paying for, i.e. berth, WS area

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

