### PR TITLE
VEN-1365 & VEN-1366 | Payment and Cancel Order Pages Fixes

### DIFF
--- a/src/common/utils/orders.ts
+++ b/src/common/utils/orders.ts
@@ -1,0 +1,13 @@
+import { OrderTypeEnum } from '../../__generated__/globalTypes';
+
+export const isOrderBerthOrWinter = (orderType: OrderTypeEnum | undefined): 'berth' | 'winter' => {
+  switch (orderType) {
+    case OrderTypeEnum.BERTH:
+    case OrderTypeEnum.ADDITIONAL_PRODUCT:
+      return 'berth';
+    case OrderTypeEnum.WINTER_STORAGE:
+      return 'winter';
+    default:
+      return 'berth';
+  }
+};

--- a/src/features/payment/cancelOrderPage/CancelOrderPage.tsx
+++ b/src/features/payment/cancelOrderPage/CancelOrderPage.tsx
@@ -9,10 +9,11 @@ import './cancelOrderPage.scss';
 
 export interface CancelOrderPageProps {
   isApplicationOrder: boolean;
+  translationContext: 'winter' | 'berth';
   handleCancel(): void;
 }
 
-const CancelOrderPage = ({ isApplicationOrder, handleCancel }: CancelOrderPageProps) => {
+const CancelOrderPage = ({ isApplicationOrder, translationContext, handleCancel }: CancelOrderPageProps) => {
   const { t } = useTranslation();
   const [confirmed, setConfirmed] = useState(false);
 
@@ -26,8 +27,12 @@ const CancelOrderPage = ({ isApplicationOrder, handleCancel }: CancelOrderPagePr
             <p>
               <strong>
                 <Trans
-                  i18nKey="page.cancel_order.message.paragraph2"
-                  tOptions={{ context: isApplicationOrder ? 'application' : undefined }}
+                  i18nKey={
+                    isApplicationOrder
+                      ? 'page.cancel_order.message.paragraph2_application'
+                      : 'page.cancel_order.message.paragraph2'
+                  }
+                  tOptions={{ context: translationContext }}
                 />
               </strong>
             </p>

--- a/src/features/payment/cancelOrderPage/CancelOrderPageContainer.tsx
+++ b/src/features/payment/cancelOrderPage/CancelOrderPageContainer.tsx
@@ -4,6 +4,7 @@ import { compose } from 'recompose';
 import CancelOrderPage from './CancelOrderPage';
 import { CANCEL_ORDER, GET_ORDER_DETAILS } from '../../queries';
 import { getOrderNumber } from '../../../common/utils/urls';
+import { isOrderBerthOrWinter } from '../../../common/utils/orders';
 import { LocalePush, withMatchParamsHandlers } from '../../../common/utils/container';
 import { CancelOrder, CancelOrderVariables } from '../../__generated__/CancelOrder';
 import LoadingPage from '../../../common/loadingPage/LoadingPage';
@@ -45,9 +46,12 @@ const CancelOrderPageContainer = ({ localePush }: Props) => {
       // eslint-disable-next-line no-console
       .catch((err) => console.error(err));
 
+  const translationContext = isOrderBerthOrWinter(orderDetailsData.orderDetails?.orderType);
+
   return (
     <CancelOrderPage
       isApplicationOrder={!!orderDetailsData.orderDetails?.isApplicationOrder}
+      translationContext={translationContext}
       handleCancel={handleCancel}
     />
   );

--- a/src/features/payment/paymentPage/ContractPage.tsx
+++ b/src/features/payment/paymentPage/ContractPage.tsx
@@ -14,11 +14,19 @@ export interface Props {
   orderNumber: string;
   orderProductDetails: React.ReactNode;
   contractAuthMethods: ContractAuthMethods[];
+  translationContext: 'winter' | 'berth';
   handleSign: (authMethod: string) => void;
   handleTerminate: () => void;
 }
 
-const PaymentPage = ({ contractAuthMethods, orderProductDetails, orderNumber, handleSign, handleTerminate }: Props) => {
+const PaymentPage = ({
+  contractAuthMethods,
+  orderProductDetails,
+  orderNumber,
+  translationContext,
+  handleSign,
+  handleTerminate,
+}: Props) => {
   const { t } = useTranslation();
   const [termsOpened, setTermsOpened] = useState<boolean>(false);
   const [termsAccepted, setTermsAccepted] = useState<boolean>(false);
@@ -33,12 +41,12 @@ const PaymentPage = ({ contractAuthMethods, orderProductDetails, orderNumber, ha
             <p className="vene-payment-page__contact-info">
               {t('page.contract.questions')}&nbsp;
               <a
-                href="mailto:venepaikat@hel.fi"
+                href="mailto:venepaikkavaraukset@hel.fi"
                 rel="noopener noreferrer"
                 target="_blank"
                 className="vene-payment-page__link"
               >
-                venepaikat@hel.fi
+                venepaikkavaraukset@hel.fi
               </a>
             </p>
           </div>
@@ -47,7 +55,9 @@ const PaymentPage = ({ contractAuthMethods, orderProductDetails, orderNumber, ha
           <div className="vene-payment-page__content vene-payment-page__accept-terms-content">
             {orderProductDetails}
             <div>
-              <h3 className="vene-payment-page__subheading">{t('page.contract.read_and_approve')}</h3>
+              <h3 className="vene-payment-page__subheading">
+                {t('page.contract.read_and_approve', { context: translationContext })}
+              </h3>
               <p className="vene-payment-page__notice">{t('page.contract.terms_notice')}</p>
               <a
                 href={`${process.env.REACT_APP_API_URL_ROOT}contract_document/${orderNumber}`}
@@ -83,9 +93,9 @@ const PaymentPage = ({ contractAuthMethods, orderProductDetails, orderNumber, ha
             </Form>
 
             <div>
-              <p>{t('page.contract.termination_note')}</p>
+              <p>{t('page.contract.termination_note', { context: translationContext })}</p>
               <Button color="danger" onClick={handleTerminate} outline>
-                {t('page.contract.terminate')}
+                {t('page.contract.terminate', { context: translationContext })}
               </Button>
             </div>
 

--- a/src/features/payment/paymentPage/PaymentPageContainer.tsx
+++ b/src/features/payment/paymentPage/PaymentPageContainer.tsx
@@ -7,6 +7,7 @@ import PaymentPage from './PaymentPage';
 import ContractPage from './ContractPage';
 import { CONFIRM_PAYMENT, FULFILL_CONTRACT, GET_ORDER_DETAILS } from '../../queries';
 import { getOrderNumber, setOrderNumber } from '../../../common/utils/urls';
+import { isOrderBerthOrWinter } from '../../../common/utils/orders';
 import GeneralPaymentErrorPage from './paymentError/GeneralPaymentErrorPage';
 import AlreadyPaidPage from './paymentError/AlreadyPaidPage';
 import PastDueDatePage from './paymentError/PastDueDatePage';
@@ -122,24 +123,22 @@ export const getPaymentPage = (
   }
 
   let orderProductDetails: React.ReactNode = null;
+  let translationContext: 'berth' | 'winter' = 'berth';
 
-  switch (orderType) {
-    case OrderTypeEnum.BERTH:
-    case OrderTypeEnum.ADDITIONAL_PRODUCT:
-      orderProductDetails = (
-        <BerthInfo harbor={placeDetails.area} pier={placeDetails.section} berth={placeDetails.place} />
-      );
-      break;
-    case OrderTypeEnum.WINTER_STORAGE:
-      orderProductDetails = <WinterStorageInfo {...placeDetails} />;
-      break;
-    default:
-      break;
+  if (isOrderBerthOrWinter(orderType) === 'berth') {
+    orderProductDetails = (
+      <BerthInfo harbor={placeDetails.area} pier={placeDetails.section} berth={placeDetails.place} />
+    );
+    translationContext = 'berth';
+  } else if (isOrderBerthOrWinter(orderType) === 'winter') {
+    orderProductDetails = <WinterStorageInfo {...placeDetails} />;
+    translationContext = 'winter';
   }
 
   if (contractSigned !== null && !contractSigned) {
     return (
       <ContractPage
+        translationContext={translationContext}
         orderProductDetails={orderProductDetails}
         orderNumber={orderNumber}
         handleSign={signContract}

--- a/src/features/payment/paymentPage/PaymentPageContainer.tsx
+++ b/src/features/payment/paymentPage/PaymentPageContainer.tsx
@@ -79,11 +79,12 @@ const PaymentPageContainer = ({ localePush }: Props) => {
     localePush(setOrderNumber('cancel-order', orderNumber));
   };
 
-  if (confirmError || orderDetailsError) {
-    return <GeneralPaymentErrorPage />;
-  }
-  if (loadingOrderDetails || loadingConfirmPayment || isRedirecting || !orderDetailsData?.contractSigned) {
+  if (loadingOrderDetails || loadingConfirmPayment || isRedirecting) {
     return <LoadingPage />;
+  }
+
+  if (confirmError || orderDetailsError || typeof orderDetailsData?.contractSigned?.isSigned !== 'boolean') {
+    return <GeneralPaymentErrorPage />;
   }
 
   return getPaymentPage(
@@ -111,7 +112,7 @@ export const getPaymentPage = (
   },
   orderType: OrderTypeEnum | undefined,
   orderNumber: string,
-  contractSigned: boolean | null,
+  contractSigned: boolean,
   status: OrderStatus | undefined | null,
   contractAuthMethods: ContractAuthMethods[],
   confirmPayment: () => void,
@@ -135,7 +136,7 @@ export const getPaymentPage = (
     translationContext = 'winter';
   }
 
-  if (contractSigned !== null && !contractSigned) {
+  if (!contractSigned) {
     return (
       <ContractPage
         translationContext={translationContext}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -611,8 +611,10 @@
       "title": "Offer/invoice cancellation",
       "message": {
         "paragraph1": "Are you sure you want to cancel the offer/invoice?",
-        "paragraph2": "NOTE! This function will cancel the following documents connected to the berth in question:<br/>lease agreement and invoice",
-        "paragraph2_application": "NOTE! If you decide not to have the offered berth or if you don’t pay the berth fee, your application will be deleted. If you want to apply for a berth again, you must make a new application at https://venepaikat.hel.fi/en/",
+        "paragraph2_berth": "NOTE! This function will cancel the following documents connected to the berth in question:<br/>lease agreement and invoice",
+        "paragraph2_winter": "NOTE! This function will cancel the following documents connected to the place in question:<br/>lease agreement and invoice",
+        "paragraph2_application_berth": "NOTE! If you decide not to have the offered berth or if you don’t pay the berth fee, your application will be deleted. If you want to apply for a berth again, you must make a new application at https://venepaikat.hel.fi/en/",
+        "paragraph2_application_winter": "NOTE! If you decide not to have the offered place or if you don’t pay the place fee, your application will be deleted. If you want to apply for a place again, you must make a new application at https://venepaikat.hel.fi/en/",
         "paragraph3": "If you do not want to cancel, you can close this page.<0/>Questions and further information: <1>venepaikkavaraukset@hel.fi</1>"
       },
       "confirmation": "I want to cancel the offer/invoice",
@@ -620,7 +622,7 @@
     },
     "order_cancelled": {
       "title_text": "The cancellation was successful!",
-      "message": "We have received the cancellation and your berth has been terminated. You will receive a confirmation to your email."
+      "message": "We have received the cancellation and your place has been terminated. You will receive a confirmation to your email."
     },
     "common": {
       "website": "Website"
@@ -717,8 +719,10 @@
       "terms_notice": "Note. The terms of the agreement must be opened and read before they can be accepted.",
       "terms_checkbox": "I have read and accept the contract terms",
       "terms_form_submit": "Continue to authentication",
-      "termination_note": "I want to give up my berth and I don’t want to pay for it anymore.",
-      "terminate": "Terminate the berth"
+      "termination_note_berth": "I want to give up my berth and I don’t want to pay for it anymore.",
+      "termination_note_winter": "I want to give up my place and I don’t want to pay for it anymore.",
+      "terminate_berth": "Terminate the berth",
+      "terminate_winter": "Terminate the place"
     },
     "payment": {
       "berth_information": "Berth",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -612,8 +612,10 @@
       "title": "Tarjouksen/laskun peruuttaminen",
       "message": {
         "paragraph1": "Oletko varma että haluat peruuttaa tarjouksen/laskun?",
-        "paragraph2": "HUOM! Tämä toiminto peruuttaa seuraavat kyseiseen paikkaan liitetyt asiakirjat:<br/>vuokrasopimus ja lasku",
-        "paragraph2_application": "HUOM! Jos päätät olla vastaanottamatta venepaikkaa, hakemuksesi raukeaa. Hakemuksesi raukeaa myös, jos et maksa venepaikkamaksua. Jos haluat hakea uudestaan venepaikkaa, sinun on tehtävä uusi hakemus osoitteessa venepaikat.hel.fi",
+        "paragraph2_berth": "HUOM! Tämä toiminto peruuttaa seuraavat kyseiseen paikkaan liitetyt asiakirjat:<br/>vuokrasopimus ja lasku",
+        "paragraph2_winter": "HUOM! Tämä toiminto peruuttaa seuraavat kyseiseen paikkaan liitetyt asiakirjat:<br/>vuokrasopimus ja lasku",
+        "paragraph2_application_berth": "HUOM! Jos päätät olla vastaanottamatta venepaikkaa, hakemuksesi raukeaa. Hakemuksesi raukeaa myös, jos et maksa venepaikkamaksua. Jos haluat hakea uudestaan venepaikkaa, sinun on tehtävä uusi hakemus osoitteessa venepaikat.hel.fi",
+        "paragraph2_application_winter": "HUOM! Jos päätät olla vastaanottamatta paikkaa, hakemuksesi raukeaa. Hakemuksesi raukeaa myös, jos et maksa paikkamaksua. Jos haluat hakea uudestaan paikkaa, sinun on tehtävä uusi hakemus osoitteessa venepaikat.hel.fi",
         "paragraph3": "Mikäli et halua peruuttaa, voit sulkea tämän sivun.<0/>Kysymykset ja lisätiedot: <1>venepaikkavaraukset@hel.fi</1>"
       },
       "confirmation": "Haluan peruuttaa tarjouksen/laskun",
@@ -718,8 +720,10 @@
       "terms_notice": "Huom. Sopimusehdot täytyy avata ja lukea ennen kuin ne voi hyväksyä.",
       "terms_checkbox": "Olen lukenut sopimusehdot ja hyväksyn ne",
       "terms_form_submit": "Jatka tunnistautumiseen",
-      "termination_note": "Haluan luopua venepaikastani enkä halua enää maksaa sitä.",
-      "terminate": "Irtisano venepaikka"
+      "termination_note_berth": "Haluan luopua venepaikastani enkä halua enää maksaa sitä.",
+      "termination_note_winter": "Haluan luopua paikastani enkä halua enää maksaa sitä.",
+      "terminate_berth": "Irtisano venepaikka",
+      "terminate_winter": "Irtisano paikka"
     },
     "payment": {
       "berth_information": "Venepaikan tiedot",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -611,8 +611,10 @@
       "title": "Annullering av erbjudande/faktura",
       "message": {
         "paragraph1": "Är du säker på att du vill annullera erbjudandet/fakturan?",
-        "paragraph2": "OBS! Denna funktion annullerar följande dokument som bifogats till respektive plats:<br/>hyresavtal och faktura",
-        "paragraph2_application": "OBS! Om du väljer att inte ta emot båtplatsen förfaller din ansökan. Din ansökan förfaller också om du inte betalar båtplatsavgiften. Om du vill ansöka om en båtplats på nytt, måste du göra en ny ansökan på adressen https://venepaikat.hel.fi/sv/",
+        "paragraph2_berth": "OBS! Denna funktion annullerar följande dokument som bifogats till respektive plats:<br/>hyresavtal och faktura",
+        "paragraph2_winter": "OBS! Denna funktion annullerar följande dokument som bifogats till respektive plats:<br/>hyresavtal och faktura",
+        "paragraph2_application_berth": "OBS! Om du väljer att inte ta emot båtplatsen förfaller din ansökan. Din ansökan förfaller också om du inte betalar båtplatsavgiften. Om du vill ansöka om en båtplats på nytt, måste du göra en ny ansökan på adressen https://venepaikat.hel.fi/sv/",
+        "paragraph2_application_winter": "OBS! Om du väljer att inte ta emot båtplatsen förfaller din ansökan. Din ansökan förfaller också om du inte betalar båtplatsavgiften. Om du vill ansöka om en vinteruppläggningsplats båtplats på nytt, måste du göra en ny ansökan på adressen https://venepaikat.hel.fi/sv/",
         "paragraph3": "Du kan stänga denna sida om du inte vill utföra en annullering.<0/>Frågor och mer information: <1>venepaikkavaraukset@hel.fi</1>"
       },
       "confirmation": "Jag vill annullera erbjudandet/fakturan",
@@ -620,7 +622,7 @@
     },
     "order_cancelled": {
       "title_text": "Avbokningen lyckades!",
-      "message": "Vi har fått avbokningen och din båtplats har avslutats. Du kommer att få en bekräftelse på din e-post."
+      "message": "Vi har fått avbokningen och din plats har avslutats. Du kommer att få en bekräftelse på din e-post."
     },
     "common": {
       "website": "Webbplats"
@@ -711,14 +713,17 @@
       "title": "Signering av avtal och betalning av faktura",
       "info": "Bästa kund, vi har lagt upp ett avtal för dig som ska signeras elektroniskt. Läs avtalet nedan. Då du godkänt avtalsvillkoren, kan du fortsätta till identifikationen och betalningen. För att få en båtplats måste du godkänna avtalsvillkoren.",
       "questions": "Frågor och mer information: ",
-      "read_and_approve": "Läs och acceptera avtalsvillkor för uthyrning av båtplats",
+      "read_and_approve_berth": "Läs och acceptera avtalsvillkor för uthyrning av båtplats",
+      "read_and_approve_winter": "Läs och acceptera avtalsvillkor för uthyrning av vinteruppläggningsplats",
       "select_signing_provider": "Signera avtalet genom att välja identifikationssätt",
       "terms_pdf": "Öppna avtalsvillkoren (PDF)",
       "terms_notice": "Notera. Villkoren i avtalet måste öppnas och läsas innan de kan accepteras.",
       "terms_checkbox": "Jag har läst avtalsvillkoren och godkänner dem",
       "terms_form_submit": "Fortsätt till identifikationen",
-      "termination_note": "Jag vill ge upp min kaj och vill inte betala för den längre.",
-      "terminate": "Avsluta båtplatsen"
+      "termination_note_berth": "Jag vill ge upp min plats och vill inte betala för den längre.",
+      "termination_note_winter": "Jag vill ge upp min plats och vill inte betala för den längre.",
+      "terminate_berth": "Avsluta båtplatsen",
+      "terminate_winter": "Avsluta platsen"
     },
     "payment": {
       "berth_information": "Båtplatsen",


### PR DESCRIPTION
## Description :sparkles:
- Fix texts on payment and cancel order pages
- Redirect users w/o order contracts to error page

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

