### PR TITLE
VEN-1355 | Create berth profile on login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
     Changes that landed in develop and might be expected in the upcoming releases.
     Click to see more.
   </summary>
-...
+
+**Changed:**
+
+- Berth profile created on login if it did not previously exist
 </details>
 
 # 1.0.2 (October 28, 2020)

--- a/src/__generated__/globalTypes.ts
+++ b/src/__generated__/globalTypes.ts
@@ -157,6 +157,11 @@ export interface CreateEmailInput {
   emailType: EmailType;
 }
 
+export interface CreateMyBerthProfileMutationInput {
+  profileToken: string;
+  clientMutationId?: string | null;
+}
+
 export interface CreatePhoneInput {
   primary?: boolean | null;
   phone: string;

--- a/src/app/auth/__tests__/authService.test.ts
+++ b/src/app/auth/__tests__/authService.test.ts
@@ -107,6 +107,20 @@ describe('authService', () => {
     });
   });
 
+  describe('getProfileToken', () => {
+    it('finds profile token', () => {
+      const profileToken = 'profile token';
+
+      jest.spyOn(Storage.prototype, 'getItem').mockReturnValueOnce(
+        JSON.stringify({
+          [process.env.REACT_APP_TUNNISTAMO_SCOPE_PROFILE as string]: profileToken,
+        })
+      );
+
+      expect(authService.getProfileToken()).toEqual(profileToken);
+    });
+  });
+
   describe('getUser', () => {
     it('should call getUser from oidc', () => {
       const getUser = jest.spyOn(userManager, 'getUser');

--- a/src/app/auth/authService.ts
+++ b/src/app/auth/authService.ts
@@ -53,6 +53,18 @@ const getTokens = (): string | null => {
   return localStorage.getItem(API_TOKENS);
 };
 
+const getProfileToken = (): string | null => {
+  const tokens = getTokens();
+
+  if (!tokens) {
+    return null;
+  }
+
+  const profileToken = JSON.parse(tokens)?.[process.env.REACT_APP_TUNNISTAMO_SCOPE_PROFILE as string];
+
+  return profileToken ?? null;
+};
+
 const getUser = (): Promise<User | null> => {
   return userManager.getUser();
 };
@@ -82,6 +94,7 @@ const authService = {
   endLogin,
   fetchApiTokens,
   getTokens,
+  getProfileToken,
   getUser,
   isAuthenticated,
   login,

--- a/src/features/__generated__/CreateMyBerthProfile.ts
+++ b/src/features/__generated__/CreateMyBerthProfile.ts
@@ -1,0 +1,23 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { CreateMyBerthProfileMutationInput } from "./../../__generated__/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: CreateMyBerthProfile
+// ====================================================
+
+export interface CreateMyBerthProfile_createMyBerthProfile {
+  __typename: "CreateMyBerthProfileMutationPayload";
+  clientMutationId: string | null;
+}
+
+export interface CreateMyBerthProfile {
+  createMyBerthProfile: CreateMyBerthProfile_createMyBerthProfile | null;
+}
+
+export interface CreateMyBerthProfileVariables {
+  input: CreateMyBerthProfileMutationInput;
+}

--- a/src/features/queries.ts
+++ b/src/features/queries.ts
@@ -281,6 +281,14 @@ export const UPDATE_PROFILE = gql`
   }
 `;
 
+export const CREATE_BERTH_PROFILE_MUTATION = gql`
+  mutation CreateMyBerthProfile($input: CreateMyBerthProfileMutationInput!) {
+    createMyBerthProfile(input: $input) {
+      clientMutationId
+    }
+  }
+`;
+
 // TODO
 // export const SWITCH_OFFER_DETAILS = gql`
 //   query SwitchOfferDetails($offerNumber: String!) {


### PR DESCRIPTION
## Description :sparkles:

Changes the login routine so that a Berth profile is added for the user after login completes.

Things to note:
- At the moment Helsinki profile automatically adds a Helsinki profile and a service connection to Berth when the user logs in with strong authentication
- Same support will be added to weak authentication later on--does not exist yet
- If the user has a Helsinki profile, but does not have a Berth profile, the Berth profile should be created

## Testing :alembic:

### Automated tests :gear:️

Extended auth test suite to cover profile token picker utility.

### Manual testing :construction_worker_man:

Expect that a Helsinki profile gets created when you login without one

