### PR TITLE
VEN-1401 | Use Kanslia's test Tunnistamo and HKI Profile in staging env

### DIFF
--- a/.env
+++ b/.env
@@ -11,6 +11,6 @@ REACT_APP_TUNNISTAMO_CLIENT_ID=https://api.hel.fi/auth/berths-ui
 REACT_APP_TUNNISTAMO_LOGOUT_ENDPOINT=logout
 REACT_APP_TUNNISTAMO_SCOPE_BERTHS=https://api.hel.fi/auth/berths
 REACT_APP_TUNNISTAMO_SCOPE_PROFILE=https://api.hel.fi/auth/helsinkiprofile
-REACT_APP_TUNNISTAMO_URI=https://tunnistamo.test.kuva.hel.ninja
+REACT_APP_TUNNISTAMO_URI=https://tunnistamo.test.hel.ninja
 SASS_PATH=src/assets:node_modules/open-city-design/src/scss
 REACT_APP_TRAILER_PAYMENT_URL=https://talpa-verkkokauppa-kassa-ui-dev.agw.arodevtest.hel.fi/purchase/306ab20a-6b30-3ce3-95e8-fef818e6c30e?language=fi&quantity=1&namespace=venepaikat

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -34,7 +34,7 @@ jobs:
           DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://venepaikka-federation.test.kuva.hel.ninja/'
           DOCKER_BUILD_ARG_REACT_APP_API_URL_ROOT: 'https://venepaikka-api.test.kuva.hel.ninja/'
           DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'development'
-          DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_URI: 'https://tunnistamo.test.kuva.hel.ninja'
+          DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_URI: 'https://tunnistamo.test.hel.ninja'
           DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_API_TOKEN_ENDPOINT: 'api-tokens'
           DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_API_TOKEN_RENEW_ENDPOINT: 'silent_renew'
           DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_LOGOUT_ENDPOINT: 'logout'

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -37,7 +37,7 @@ jobs:
           DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://venepaikka-federation.test.kuva.hel.ninja/'
           DOCKER_BUILD_ARG_REACT_APP_API_URL_ROOT: 'https://venepaikka-api.test.kuva.hel.ninja/'
           DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'development'
-          DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_URI: 'https://tunnistamo.test.kuva.hel.ninja'
+          DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_URI: 'https://tunnistamo.test.hel.ninja'
           DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_API_TOKEN_ENDPOINT: 'api-tokens'
           DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_API_TOKEN_RENEW_ENDPOINT: 'silent_renew'
           DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_LOGOUT_ENDPOINT: 'logout'

--- a/src/app/auth/__tests__/__snapshots__/authService.test.ts.snap
+++ b/src/app/auth/__tests__/__snapshots__/authService.test.ts.snap
@@ -4,7 +4,7 @@ exports[`authService fetchApiTokens should call axios.get with the right argumen
 Array [
   "api-tokens/",
   Object {
-    "baseURL": "https://tunnistamo.test.kuva.hel.ninja",
+    "baseURL": "https://tunnistamo.test.hel.ninja",
     "headers": Object {
       "Authorization": "bearer db237bc3-e197-43de-8c86-3feea4c5f886",
     },

--- a/src/features/profile/ProfileDebug.tsx
+++ b/src/features/profile/ProfileDebug.tsx
@@ -49,7 +49,7 @@ export const ProfileDebug = ({ error }: { error?: ApolloError }) => {
       {error && <p style={{ color: 'red' }}>Error: {error.message}</p>}
 
       <p>
-        <a href="https://profiili.test.kuva.hel.ninja/" rel="noopener noreferrer" target="_blank">
+        <a href="https://profiili.test.hel.ninja/" rel="noopener noreferrer" target="_blank">
           <button type="button">Open Profile UI</button>
         </a>
       </p>


### PR DESCRIPTION
## Description :sparkles:

Switch the staging and review environments to use Kanslia's test Tunnistamo and HKI Profile to be able to test Suomi.fi strong authentication. Requires the same changes to [the backend](https://github.com/City-of-Helsinki/berth-reservations/pull/618) and to [the federation gateway](https://github.com/City-of-Helsinki/berth-federation-gateway/pull/39).

## Issues :bug:
### Related :handshake:
**[VEN-1401](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1401)** 


## Testing :alembic:

### Manual testing :construction_worker_man:

It is not possible to fully test this before merging, but most parts can be tested locally. 

## Additional notes :spiral_notepad:

Currently it is not possible to get PR environments' authentication to actually work with Kanslia's Tunnistamo, but those envs are not working at the moment anyway, so we switch them to Kanslia's Tunnistamo to prevent confusion in the future.