### PR TITLE
VEN-1421 | Provide currentUser that matches typedefs

### DIFF
--- a/src/app/auth/callbackPage/CallbackPage.tsx
+++ b/src/app/auth/callbackPage/CallbackPage.tsx
@@ -28,8 +28,17 @@ const CallbackPage = ({ history }: CallbackPageProps) => {
           },
         });
 
+        const { name, email, sub } = user.profile;
+
         client.writeData({
-          data: { currentUser: { __typename: 'CurrentUser', ...user.profile } },
+          data: {
+            currentUser: {
+              __typename: 'CurrentUser',
+              name,
+              email,
+              id: sub,
+            },
+          },
         });
 
         history.replace(user.state.path);


### PR DESCRIPTION
## Description :sparkles:

Provide a currentUser that matches typedefs so that Apollo doesn't raise error on missing ID and stop the after-login-redirect from succeeding.

## Reproduction

1. Login
2. Access private route (for instance /profile/:id)
2. Delete api keys from locale storage (emulate their expiration)
3. Refresh
4. Expect login to take place
5. Expect login to hand indefinitely



