### PR TITLE
VEN-1400 | Allow user to extend application

### DIFF
--- a/src/__generated__/globalTypes.ts
+++ b/src/__generated__/globalTypes.ts
@@ -14,6 +14,16 @@ export enum AddressType {
   WORK = "WORK",
 }
 
+export enum ApplicationStatus {
+  EXPIRED = "EXPIRED",
+  HANDLED = "HANDLED",
+  NO_SUITABLE_BERTHS = "NO_SUITABLE_BERTHS",
+  OFFER_GENERATED = "OFFER_GENERATED",
+  OFFER_SENT = "OFFER_SENT",
+  PENDING = "PENDING",
+  REJECTED = "REJECTED",
+}
+
 export enum ContactMethod {
   EMAIL = "EMAIL",
   SMS = "SMS",
@@ -174,6 +184,11 @@ export interface CreateWinterStorageApplicationMutationInput {
 }
 
 export interface DeleteBerthApplicationMutationInput {
+  id: string;
+  clientMutationId?: string | null;
+}
+
+export interface ExtendBerthApplicationMutationInput {
   id: string;
   clientMutationId?: string | null;
 }

--- a/src/features/profile/berths/Berths.tsx
+++ b/src/features/profile/berths/Berths.tsx
@@ -19,9 +19,17 @@ export interface BerthsProps {
   invoice: InvoiceData<BerthSpecs> | null;
   reservations: ReservationHistoryProps['reservations'] | null;
   onDeleteApplication(berthApplicationId: string): void;
+  onExtendApplication(berthApplicationId: string): void;
 }
 
-const Berths = ({ applications, offer, invoice, reservations, onDeleteApplication }: BerthsProps) => {
+const Berths = ({
+  applications,
+  offer,
+  invoice,
+  reservations,
+  onDeleteApplication,
+  onExtendApplication,
+}: BerthsProps) => {
   const {
     t,
     i18n: { language },
@@ -126,6 +134,7 @@ const Berths = ({ applications, offer, invoice, reservations, onDeleteApplicatio
           <Application
             applicationDate={application.applicationDate}
             choices={application.choices}
+            status={application.status}
             subHeading={t('page.profile.berths.berth_offer.applied_berths')}
             heading={!offer && !invoice ? t('page.profile.berths.berth_offer.berth_application') : undefined}
             renderProperties={({ electricity, gate, lighting, wasteCollection, water }) => (
@@ -139,6 +148,7 @@ const Berths = ({ applications, offer, invoice, reservations, onDeleteApplicatio
             )}
             disableButtons={!!offer}
             onDelete={() => onDeleteApplication(application.id)}
+            onExtendApplication={() => onExtendApplication(application.id)}
           />
           <Divider />
         </Fragment>

--- a/src/features/profile/berths/BerthsContainer.tsx
+++ b/src/features/profile/berths/BerthsContainer.tsx
@@ -11,9 +11,14 @@ import {
   DELETE_BERTH_APPLICATION,
   DELETE_BERTH_APPLICATIONVariables as DELETE_BERTH_APPLICATION_VAR,
 } from './__generated__/DELETE_BERTH_APPLICATION';
+import {
+  EXTEND_BERTH_APPLICATION,
+  EXTEND_BERTH_APPLICATIONVariables as EXTEND_BERTH_APPLICATION_VAR,
+} from './__generated__/EXTEND_BERTH_APPLICATION';
 import Berths from './Berths';
-import { BERTHS_QUERY, DELETE_BERTH_APPLICATION_MUTATION } from './queries';
+import { BERTHS_QUERY, DELETE_BERTH_APPLICATION_MUTATION, EXTEND_BERTH_APPLICATION_MUTATION } from './queries';
 import { getChoicesFromBerthApplication } from './utils';
+import { BerthApplicationNodeCertainly } from './types';
 
 const BerthsContainer = () => {
   // TODO: Get real data
@@ -29,11 +34,21 @@ const BerthsContainer = () => {
       refetchQueries: [getOperationName(BERTHS_QUERY) || 'BERTHS_QUERY'],
     }
   );
+  const [extendBerthApplication] = useMutation<EXTEND_BERTH_APPLICATION, EXTEND_BERTH_APPLICATION_VAR>(
+    EXTEND_BERTH_APPLICATION_MUTATION,
+    {
+      refetchQueries: [getOperationName(BERTHS_QUERY) || 'BERTHS_QUERY'],
+    }
+  );
 
-  const berthApplications = data?.myProfile?.berthApplications?.edges?.map((edge) => edge?.node) ?? [];
+  const berthApplications =
+    data?.myProfile?.berthApplications?.edges
+      ?.map((edge) => edge?.node)
+      .filter((node): node is BerthApplicationNodeCertainly => Boolean(node)) ?? [];
   const applications = berthApplications.map((berthApplication) => ({
-    id: berthApplication?.id || '',
-    applicationDate: berthApplication?.createdAt,
+    id: berthApplication.id,
+    status: berthApplication.status,
+    applicationDate: berthApplication.createdAt,
     choices: getChoicesFromBerthApplication(berthApplication),
   }));
 
@@ -59,6 +74,16 @@ const BerthsContainer = () => {
     });
   };
 
+  const handleExtendApplication = (berthApplicationId: string) => {
+    extendBerthApplication({
+      variables: {
+        input: {
+          id: berthApplicationId,
+        },
+      },
+    });
+  };
+
   return (
     <Berths
       offer={offer}
@@ -66,6 +91,7 @@ const BerthsContainer = () => {
       reservations={reservations}
       applications={applications}
       onDeleteApplication={handleDeleteApplication}
+      onExtendApplication={handleExtendApplication}
     />
   );
 };

--- a/src/features/profile/berths/__fixtures__/mockData.ts
+++ b/src/features/profile/berths/__fixtures__/mockData.ts
@@ -1,4 +1,4 @@
-import { OrderStatus } from '../../../../__generated__/globalTypes';
+import { OrderStatus, ApplicationStatus } from '../../../../__generated__/globalTypes';
 import { Area } from '../../components/placeInfo/PlaceInfo';
 import { BerthsProps } from '../Berths';
 import { Properties } from '../types';
@@ -204,6 +204,7 @@ const application = {
   id: 'abc-123',
   applicationDate: 'Thu May 28 2020 23:21:00 GMT+0300 (Eastern European Summer Time)',
   choices: mockCustomerBerthsProps.choices,
+  status: ApplicationStatus.PENDING,
 };
 
 const reservations = [
@@ -236,6 +237,9 @@ export const getCustomerBerthsProps = (id: string): BerthsProps => {
         onDeleteApplication: () => {
           // pass
         },
+        onExtendApplication: () => {
+          // pass
+        },
       };
 
     case '2':
@@ -248,6 +252,9 @@ export const getCustomerBerthsProps = (id: string): BerthsProps => {
         onDeleteApplication: () => {
           // pass
         },
+        onExtendApplication: () => {
+          // pass
+        },
       };
 
     case '3':
@@ -258,6 +265,9 @@ export const getCustomerBerthsProps = (id: string): BerthsProps => {
         invoice: { ...mockCustomerBerthsProps, contract: null },
         reservations,
         onDeleteApplication: () => {
+          // pass
+        },
+        onExtendApplication: () => {
           // pass
         },
       };
@@ -280,6 +290,9 @@ export const getCustomerBerthsProps = (id: string): BerthsProps => {
         onDeleteApplication: () => {
           // pass
         },
+        onExtendApplication: () => {
+          // pass
+        },
       };
 
     default:
@@ -290,6 +303,9 @@ export const getCustomerBerthsProps = (id: string): BerthsProps => {
         invoice: null,
         reservations: null,
         onDeleteApplication: () => {
+          // pass
+        },
+        onExtendApplication: () => {
           // pass
         },
       };

--- a/src/features/profile/berths/__generated__/BERTHS.ts
+++ b/src/features/profile/berths/__generated__/BERTHS.ts
@@ -3,6 +3,8 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
+import { ApplicationStatus } from "./../../../../__generated__/globalTypes";
+
 // ====================================================
 // GraphQL query operation: BERTHS
 // ====================================================
@@ -39,6 +41,7 @@ export interface BERTHS_myProfile_berthApplications_edges_node {
   __typename: "BerthApplicationNode";
   id: string;
   createdAt: any;
+  status: ApplicationStatus;
   harborChoices: (BERTHS_myProfile_berthApplications_edges_node_harborChoices | null)[] | null;
 }
 

--- a/src/features/profile/berths/__generated__/EXTEND_BERTH_APPLICATION.ts
+++ b/src/features/profile/berths/__generated__/EXTEND_BERTH_APPLICATION.ts
@@ -1,0 +1,23 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { ExtendBerthApplicationMutationInput } from "./../../../../__generated__/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: EXTEND_BERTH_APPLICATION
+// ====================================================
+
+export interface EXTEND_BERTH_APPLICATION_extendBerthApplication {
+  __typename: "ExtendBerthApplicationMutationPayload";
+  clientMutationId: string | null;
+}
+
+export interface EXTEND_BERTH_APPLICATION {
+  extendBerthApplication: EXTEND_BERTH_APPLICATION_extendBerthApplication | null;
+}
+
+export interface EXTEND_BERTH_APPLICATIONVariables {
+  input: ExtendBerthApplicationMutationInput;
+}

--- a/src/features/profile/berths/__generated__/berthApplicationNodeFragment.ts
+++ b/src/features/profile/berths/__generated__/berthApplicationNodeFragment.ts
@@ -3,6 +3,8 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
+import { ApplicationStatus } from "./../../../../__generated__/globalTypes";
+
 // ====================================================
 // GraphQL fragment: berthApplicationNodeFragment
 // ====================================================
@@ -39,5 +41,6 @@ export interface berthApplicationNodeFragment {
   __typename: "BerthApplicationNode";
   id: string;
   createdAt: any;
+  status: ApplicationStatus;
   harborChoices: (berthApplicationNodeFragment_harborChoices | null)[] | null;
 }

--- a/src/features/profile/berths/queries.ts
+++ b/src/features/profile/berths/queries.ts
@@ -4,6 +4,7 @@ const BERTH_APPLICATION_NODE = gql`
   fragment berthApplicationNodeFragment on BerthApplicationNode {
     id
     createdAt
+    status
     harborChoices {
       harbor {
         id
@@ -43,6 +44,14 @@ export const BERTHS_QUERY = gql`
 export const DELETE_BERTH_APPLICATION_MUTATION = gql`
   mutation DELETE_BERTH_APPLICATION($input: DeleteBerthApplicationMutationInput!) {
     deleteBerthApplication(input: $input) {
+      clientMutationId
+    }
+  }
+`;
+
+export const EXTEND_BERTH_APPLICATION_MUTATION = gql`
+  mutation EXTEND_BERTH_APPLICATION($input: ExtendBerthApplicationMutationInput!) {
+    extendBerthApplication(input: $input) {
       clientMutationId
     }
   }

--- a/src/features/profile/berths/types.ts
+++ b/src/features/profile/berths/types.ts
@@ -1,3 +1,5 @@
+import { berthApplicationNodeFragment as BerthApplicationNode } from './__generated__/berthApplicationNodeFragment';
+
 export interface BerthSpecs {
   pier: string;
   berthLength: number;
@@ -7,8 +9,7 @@ export interface BerthSpecs {
 }
 
 export type Properties = Record<'electricity' | 'gate' | 'lighting' | 'wasteCollection' | 'water', boolean>;
+export type BerthApplicationNodeCertainly = Exclude<BerthApplicationNode, null | undefined>;
 
-export type {
-  berthApplicationNodeFragment as BerthApplicationNode,
-  berthApplicationNodeFragment_harborChoices as HarborChoice,
-} from './__generated__/berthApplicationNodeFragment';
+export type { BerthApplicationNode };
+export type { berthApplicationNodeFragment_harborChoices as HarborChoice } from './__generated__/berthApplicationNodeFragment';

--- a/src/features/profile/components/application/Application.tsx
+++ b/src/features/profile/components/application/Application.tsx
@@ -4,8 +4,11 @@ import { useTranslation } from 'react-i18next';
 
 import AvailabilityLevel from '../../../../common/availabilityLevel/AvailabilityLevel';
 import { formatDate } from '../../../../common/utils/format';
+import { ApplicationStatus } from '../../../../__generated__/globalTypes';
 import { Choice } from '../../types';
 import ConfirmIntent from '../confirmIntent/ConfirmIntent';
+import ApplicationNoSuitableBerths from './ApplicationNoSuitableBerthsNotice';
+import Divider from '../divider/Divider';
 import './application.scss';
 
 export interface ApplicationProps<T extends Record<string, boolean>> {
@@ -14,7 +17,9 @@ export interface ApplicationProps<T extends Record<string, boolean>> {
   heading?: string;
   subHeading: string;
   disableButtons?: boolean;
+  status: ApplicationStatus;
   onDelete?: () => void;
+  onExtendApplication?: () => void;
   renderProperties(properties: T): React.ReactNode;
 }
 
@@ -24,7 +29,9 @@ const Application = <T extends Record<string, boolean>>({
   applicationDate,
   choices,
   disableButtons,
+  status,
   renderProperties,
+  onExtendApplication,
   onDelete,
 }: ApplicationProps<T>) => {
   const {
@@ -44,44 +51,46 @@ const Application = <T extends Record<string, boolean>>({
 
   return (
     <div className="vene-application">
-      {heading && <h1>{heading}</h1>}
+      {status === ApplicationStatus.NO_SUITABLE_BERTHS && onExtendApplication && (
+        <>
+          <ApplicationNoSuitableBerths onExtendApplication={onExtendApplication} />
+          <Divider />
+        </>
+      )}
+
+      {heading && <h2 className="vene-application__heading">{heading}</h2>}
 
       <p>
         {t('common.sent')}: {formatDate(applicationDate, language)}
       </p>
 
-      <h2 className="vene-application__heading">{subHeading}</h2>
+      <h3 className="vene-application__sub-heading">{subHeading}</h3>
       <ol className="vene-application__choices">{choices.map(renderChoices)}</ol>
 
-      {/* Removing the checkbox until the design is ready
-      <Checkbox
-        checked
-        id="keep-application-active"
-        labelText={t('page.profile.application.keep_application_active')}
-      /> */}
-
-      <div className="vene-application__buttons">
-        <Button size="small" variant="secondary" disabled={disableButtons}>
-          {t('page.profile.application.edit_application')}
-        </Button>
-        {onDelete && (
-          <div className="vene-application__button">
-            <ConfirmIntent
-              id="delete-berth-application"
-              title={t('page.profile.application.confirm_delete_title')}
-              cancelIntentLabel={t('page.profile.application.confirm_delete_cancel')}
-              confirmIntentLabel={t('page.profile.application.confirm_delete_confirm')}
-              description={t('page.profile.application.confirm_delete_description')}
-              intent={() => onDelete()}
-              renderControl={({ ref, onClick }) => (
-                <Button ref={ref} size="small" variant="danger" onClick={onClick}>
-                  {t('page.profile.application.delete_application')}
-                </Button>
-              )}
-            />
-          </div>
-        )}
-      </div>
+      {status === ApplicationStatus.PENDING && (
+        <div className="vene-application__buttons">
+          <Button size="small" variant="secondary" disabled={disableButtons}>
+            {t('page.profile.application.edit_application')}
+          </Button>
+          {onDelete && (
+            <div className="vene-application__button">
+              <ConfirmIntent
+                id="delete-berth-application"
+                title={t('page.profile.application.confirm_delete_title')}
+                cancelIntentLabel={t('page.profile.application.confirm_delete_cancel')}
+                confirmIntentLabel={t('page.profile.application.confirm_delete_confirm')}
+                description={t('page.profile.application.confirm_delete_description')}
+                intent={() => onDelete()}
+                renderControl={({ ref, onClick }) => (
+                  <Button ref={ref} size="small" variant="danger" onClick={onClick}>
+                    {t('page.profile.application.delete_application')}
+                  </Button>
+                )}
+              />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/features/profile/components/application/ApplicationNoSuitableBerthsNotice.tsx
+++ b/src/features/profile/components/application/ApplicationNoSuitableBerthsNotice.tsx
@@ -1,0 +1,46 @@
+import { Checkbox, IconFaceSad, IconInfoCircle, Button } from 'hds-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import './applicationNoSuitableBerths.scss';
+
+export interface Props {
+  onExtendApplication: () => void;
+}
+
+const ApplicationNoSuitableBerths = ({ onExtendApplication }: Props) => {
+  const { t } = useTranslation();
+  const [continueIntent, setContinueInter] = useState(false);
+
+  return (
+    <>
+      <div className="vene-applicationNoSuitableBerths__title">
+        <IconFaceSad size="xl" aria-hidden="true" /> <h1>{t('page.profile.application.no_berths')}</h1>
+      </div>
+      <div className="vene-applicationNoSuitableBerths__stack">
+        <p>{t('page.profile.application.extend_application_explanation')}</p>
+        <Checkbox
+          checked={continueIntent}
+          id="keep-application-active"
+          label={t('page.profile.application.keep_application_active')}
+          onChange={() => setContinueInter((prev) => !prev)}
+          className="vene-applicationNoSuitableBerths__checkbox"
+        />
+        <p className="vene-applicationNoSuitableBerths__notice">
+          <IconInfoCircle size="s" /> {t('page.profile.application.application_will_be_deleted_explanation')}
+        </p>
+        <Button
+          variant="secondary"
+          disabled={!continueIntent}
+          onClick={onExtendApplication}
+          size="small"
+          className="vene-applicationNoSuitableBerths__button"
+        >
+          {t('page.profile.application.confirm_my_choice')}
+        </Button>
+      </div>
+    </>
+  );
+};
+
+export default ApplicationNoSuitableBerths;

--- a/src/features/profile/components/application/ApplicationNoSuitableBerthsNotice.tsx
+++ b/src/features/profile/components/application/ApplicationNoSuitableBerthsNotice.tsx
@@ -10,7 +10,7 @@ export interface Props {
 
 const ApplicationNoSuitableBerths = ({ onExtendApplication }: Props) => {
   const { t } = useTranslation();
-  const [continueIntent, setContinueInter] = useState(false);
+  const [continueIntent, setContinueIntent] = useState(false);
 
   return (
     <>
@@ -23,7 +23,7 @@ const ApplicationNoSuitableBerths = ({ onExtendApplication }: Props) => {
           checked={continueIntent}
           id="keep-application-active"
           label={t('page.profile.application.keep_application_active')}
-          onChange={() => setContinueInter((prev) => !prev)}
+          onChange={() => setContinueIntent((prev) => !prev)}
           className="vene-applicationNoSuitableBerths__checkbox"
         />
         <p className="vene-applicationNoSuitableBerths__notice">

--- a/src/features/profile/components/application/application.scss
+++ b/src/features/profile/components/application/application.scss
@@ -5,7 +5,7 @@
   margin-top: $spacing-03;
 
   &__heading {
-    font-size: 1.25rem;
+    font-size: $spacing-01-50;
   }
 
   &__sub-heading {

--- a/src/features/profile/components/application/application.scss
+++ b/src/features/profile/components/application/application.scss
@@ -1,11 +1,16 @@
 @import 'styles/variables';
+@import 'helsinki/fonts';
 
 .vene-application {
   margin-top: $spacing-03;
 
   &__heading {
+    font-size: 1.25rem;
+  }
+
+  &__sub-heading {
     margin-top: $spacing-02;
-    font-size: $spacing-01;
+    font-size: $font-size-base;
   }
 
   &__choices {

--- a/src/features/profile/components/application/applicationNoSuitableBerths.scss
+++ b/src/features/profile/components/application/applicationNoSuitableBerths.scss
@@ -26,7 +26,7 @@
     }
 
     & > :not(:last-child) {
-      margin-bottom: 1.25rem;
+      margin-bottom: $spacing-01-50;
     }
   }
 
@@ -36,6 +36,6 @@
 
   &__button {
     width: fit-content;
-    margin-top: 0.25rem;
+    margin-top: $spacing-00-25;
   }
 }

--- a/src/features/profile/components/application/applicationNoSuitableBerths.scss
+++ b/src/features/profile/components/application/applicationNoSuitableBerths.scss
@@ -1,0 +1,41 @@
+@import 'styles/variables';
+@import 'helsinki/fonts';
+
+.vene-applicationNoSuitableBerths {
+  &__title {
+    display: flex;
+    align-items: center;
+    margin-bottom: $spacing-03;
+
+    & > svg:first-child {
+      margin-right: $spacing-01;
+    }
+  }
+
+  &__checkbox label {
+    font-weight: 400;
+  }
+
+  &__stack {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: $spacing-03;
+
+    & > * {
+      flex-grow: 0;
+    }
+
+    & > :not(:last-child) {
+      margin-bottom: 1.25rem;
+    }
+  }
+
+  &__notice {
+    font-size: $font-size-sm;
+  }
+
+  &__button {
+    width: fit-content;
+    margin-top: 0.25rem;
+  }
+}

--- a/src/features/profile/types.ts
+++ b/src/features/profile/types.ts
@@ -1,4 +1,4 @@
-import { OrderStatus, Language } from '../../__generated__/globalTypes';
+import { OrderStatus, Language, ApplicationStatus } from '../../__generated__/globalTypes';
 
 export type ContactInfo = {
   address: string;
@@ -57,6 +57,7 @@ export interface ApplicationData<T extends Record<string, boolean>> {
   id: string;
   applicationDate: string;
   choices: Choice<T>[];
+  status: ApplicationStatus;
 }
 
 export interface OfferData<PlaceSpecs> {

--- a/src/features/profile/winterStorage/__fixtures__/mockData.ts
+++ b/src/features/profile/winterStorage/__fixtures__/mockData.ts
@@ -1,4 +1,4 @@
-import { OrderStatus } from '../../../../__generated__/globalTypes';
+import { OrderStatus, ApplicationStatus } from '../../../../__generated__/globalTypes';
 import { WinterStorageProps } from '../WinterStorage';
 import { Properties } from '../types';
 import { Choice, Order } from '../../types';
@@ -188,6 +188,7 @@ const application = {
   id: 'abc-123',
   applicationDate: 'Thu May 28 2020 23:21:00 GMT+0300 (Eastern European Summer Time)',
   choices: mockCustomerBerthsProps.choices,
+  status: ApplicationStatus.PENDING,
 };
 
 const reservations = [

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -747,7 +747,11 @@
       "application": {
         "delete_application": "Delete application",
         "edit_application": "Edit application",
-        "keep_application_active": "I want the application to remain valid if there are no free berths for this sailing season",
+        "keep_application_active": "I want the application to remain valid",
+        "no_berths": "EN: Valitettavasti hakemiasi paikkoja ei ole vapaan",
+        "extend_application_explanation": "EN: Voit halutessasi jättää hakemuksen voimaan seuraavalle kaudelle. Käsittelemme hakemuksia taas ensi vuonna.",
+        "application_will_be_deleted_explanation": "EN: Hakemus poistetaan mikäli et halua sen jäävän voimaan.",
+        "confirm_my_choice": "EN: Vahvista valintani",
         "confirm_delete_title": "EN: Haluatko varmasti poistaa hakemuksen?",
         "confirm_delete_description": "EN: Poistettuasi hakemuksen et voi enää tarkastella sen tietoja.",
         "confirm_delete_confirm": "EN: Poista hakemus",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -748,7 +748,7 @@
         "delete_application": "Delete application",
         "edit_application": "Edit application",
         "keep_application_active": "I want the application to remain valid",
-        "no_berths": "EN: Valitettavasti hakemiasi paikkoja ei ole vapaan",
+        "no_berths": "EN: Valitettavasti hakemiasi paikkoja ei ole vapaana",
         "extend_application_explanation": "EN: Voit halutessasi jättää hakemuksen voimaan seuraavalle kaudelle. Käsittelemme hakemuksia taas ensi vuonna.",
         "application_will_be_deleted_explanation": "EN: Hakemus poistetaan mikäli et halua sen jäävän voimaan.",
         "confirm_my_choice": "EN: Vahvista valintani",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -749,7 +749,7 @@
         "delete_application": "Poista hakemus",
         "edit_application": "Muokkaa hakemusta",
         "keep_application_active": "Haluan että hakemus jää voimaan",
-        "no_berths": "Valitettavasti hakemiasi paikkoja ei ole vapaan",
+        "no_berths": "Valitettavasti hakemiasi paikkoja ei ole vapaana",
         "extend_application_explanation": "Voit halutessasi jättää hakemuksen voimaan seuraavalle kaudelle. Käsittelemme hakemuksia taas ensi vuonna.",
         "application_will_be_deleted_explanation": "Hakemus poistetaan mikäli et halua sen jäävän voimaan.",
         "confirm_my_choice": "Vahvista valintani",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -748,7 +748,11 @@
       "application": {
         "delete_application": "Poista hakemus",
         "edit_application": "Muokkaa hakemusta",
-        "keep_application_active": "Haluan että hakemus jää voimaan mikäli paikkoja ei ole vapaana tälle purjehduskaudelle",
+        "keep_application_active": "Haluan että hakemus jää voimaan",
+        "no_berths": "Valitettavasti hakemiasi paikkoja ei ole vapaan",
+        "extend_application_explanation": "Voit halutessasi jättää hakemuksen voimaan seuraavalle kaudelle. Käsittelemme hakemuksia taas ensi vuonna.",
+        "application_will_be_deleted_explanation": "Hakemus poistetaan mikäli et halua sen jäävän voimaan.",
+        "confirm_my_choice": "Vahvista valintani",
         "confirm_delete_title": "Haluatko varmasti poistaa hakemuksen?",
         "confirm_delete_description": "Poistettuasi hakemuksen et voi enää tarkastella sen tietoja.",
         "confirm_delete_confirm": "Poista hakemus",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -748,7 +748,11 @@
       "application": {
         "delete_application": "Ta bort ansökan",
         "edit_application": "Redigera ansökan",
-        "keep_application_active": "Jag vill att ansökan ska vara giltig om det inte finns några lediga platser för denna seglingssäsong",
+        "keep_application_active": "Jag vill att ansökan ska vara giltig",
+        "no_berths": "SV: Valitettavasti hakemiasi paikkoja ei ole vapaan",
+        "extend_application_explanation": "SV: Voit halutessasi jättää hakemuksen voimaan seuraavalle kaudelle. Käsittelemme hakemuksia taas ensi vuonna.",
+        "application_will_be_deleted_explanation": "SV: Hakemus poistetaan mikäli et halua sen jäävän voimaan.",
+        "confirm_my_choice": "SV: Vahvista valintani",
         "confirm_delete_title": "SV: Haluatko varmasti poistaa hakemuksen?",
         "confirm_delete_description": "SV: Poistettuasi hakemuksen et voi enää tarkastella sen tietoja.",
         "confirm_delete_confirm": "SV: Poista hakemus",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -749,7 +749,7 @@
         "delete_application": "Ta bort ansökan",
         "edit_application": "Redigera ansökan",
         "keep_application_active": "Jag vill att ansökan ska vara giltig",
-        "no_berths": "SV: Valitettavasti hakemiasi paikkoja ei ole vapaan",
+        "no_berths": "SV: Valitettavasti hakemiasi paikkoja ei ole vapaana",
         "extend_application_explanation": "SV: Voit halutessasi jättää hakemuksen voimaan seuraavalle kaudelle. Käsittelemme hakemuksia taas ensi vuonna.",
         "application_will_be_deleted_explanation": "SV: Hakemus poistetaan mikäli et halua sen jäävän voimaan.",
         "confirm_my_choice": "SV: Vahvista valintani",


### PR DESCRIPTION
## Description :sparkles:

When a user's application is in the status `NO_SUITABLE_BERTHS`, show an UI that allows the user to extend their application--in which case it is set to state `PEDING` and will be reviewed again next year.

Slight adjustments to typo to facilitate new heading order--not sure if the "no berths" should be `h1`, but I labeled it so as it the design suggested it was the highest in the hierarchy.

## Screenshots :camera_flash:

<img width="1680" alt="Screenshot 2021-11-22 at 16 50 18" src="https://user-images.githubusercontent.com/9090689/142882337-9b666889-17ec-4573-812c-14c8d59e0546.png">
<img width="1680" alt="Screenshot 2021-11-22 at 16 50 28" src="https://user-images.githubusercontent.com/9090689/142882345-c8bb9220-2b96-438a-9e84-c5db746bbcdd.png">

