### PR TITLE
Add the missing offer details query to berth switch offer

### DIFF
--- a/src/__generated__/globalTypes.ts
+++ b/src/__generated__/globalTypes.ts
@@ -42,6 +42,15 @@ export enum Language {
   SWEDISH = "SWEDISH",
 }
 
+export enum OfferStatus {
+  ACCEPTED = "ACCEPTED",
+  CANCELLED = "CANCELLED",
+  DRAFTED = "DRAFTED",
+  EXPIRED = "EXPIRED",
+  OFFERED = "OFFERED",
+  REJECTED = "REJECTED",
+}
+
 export enum OrderStatus {
   CANCELLED = "CANCELLED",
   DRAFTED = "DRAFTED",

--- a/src/features/__generated__/OfferDetails.ts
+++ b/src/features/__generated__/OfferDetails.ts
@@ -1,0 +1,26 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { OfferStatus } from "./../../__generated__/globalTypes";
+
+// ====================================================
+// GraphQL query operation: OfferDetails
+// ====================================================
+
+export interface OfferDetails_offerDetails {
+  __typename: "OfferDetailsType";
+  status: OfferStatus;
+  harbor: string;
+  pier: string;
+  berth: string;
+}
+
+export interface OfferDetails {
+  offerDetails: OfferDetails_offerDetails | null;
+}
+
+export interface OfferDetailsVariables {
+  offerNumber: string;
+}

--- a/src/features/berthSwitchOffer/BerthSwitchOfferPage.tsx
+++ b/src/features/berthSwitchOffer/BerthSwitchOfferPage.tsx
@@ -3,14 +3,11 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import Layout from '../../common/layout/Layout';
+import { OfferDetails_offerDetails } from '../__generated__/OfferDetails';
 import './berthSwitchOfferPage.scss';
 
 type BerthSwitchOfferPageProps = {
-  berthDetails: {
-    harbor: string;
-    pier: string;
-    berth: string;
-  };
+  berthDetails: OfferDetails_offerDetails;
   initialChoice?: boolean;
   onConfirm(isAccepted: boolean): void;
 };
@@ -37,10 +34,16 @@ const BerthSwitchOfferPage = ({ berthDetails, initialChoice, onConfirm }: BerthS
 
         <div className="vene-offer-page__content">
           <div className="vene-offer-page__berth-info">
-            <p className="vene-offer-page__berth-info-label">Venepaikan tiedot:</p>
-            <p>Satama: {berthDetails.harbor}</p>
-            <p>Laituri: {berthDetails.pier}</p>
-            <p>Paikka: {berthDetails.berth}</p>
+            <p className="vene-offer-page__berth-info-label">{t('page.payment.berth_information')}:</p>
+            <p>
+              {t('common.harbor')}: {berthDetails.harbor}
+            </p>
+            <p>
+              {t('common.pier')}: {berthDetails.pier}
+            </p>
+            <p>
+              {t('common.berth')}: {berthDetails.berth}
+            </p>
           </div>
 
           <div className="vene-offer-page__choices">

--- a/src/features/berthSwitchOffer/BerthSwitchOfferPageContainer.tsx
+++ b/src/features/berthSwitchOffer/BerthSwitchOfferPageContainer.tsx
@@ -1,11 +1,14 @@
-import { useMutation } from '@apollo/react-hooks';
+import { useMutation, useQuery } from '@apollo/react-hooks';
 import { compose } from 'recompose';
 
 import { LocalePush, withMatchParamsHandlers } from '../../common/utils/container';
 import { getAccept, getOfferNumber } from '../../common/utils/urls';
 import { AcceptBerthSwitchOffer, AcceptBerthSwitchOfferVariables } from '../__generated__/AcceptBerthSwitchOffer';
 import BerthSwitchOfferPage from './BerthSwitchOfferPage';
-import { ACCEPT_BERTH_SWITCH_OFFER } from '../queries';
+import { ACCEPT_BERTH_SWITCH_OFFER, OFFER_DETAILS } from '../queries';
+import LoadingPage from '../../common/loadingPage/LoadingPage';
+import { OfferDetails, OfferDetailsVariables } from '../__generated__/OfferDetails';
+import GeneralOfferErrorPage from './offerError/GeneralOfferErrorPage';
 
 type Props = {
   localePush: LocalePush;
@@ -15,15 +18,12 @@ const BerthSwitchOfferPageContainer = ({ localePush }: Props) => {
   const offerNumber = getOfferNumber(window.location.search);
   const initialChoice = getAccept(window.location.search);
 
-  // TODO
-  // const { data, loading } = useQuery<SwitchOfferBerthDetails, SwitchOfferBerthDetailsVariables>(
-  //   SWITCH_OFFER_BERTH_DETAILS,
-  //   {
-  //     variables: {
-  //       offerNumber,
-  //     },
-  //   }
-  // );
+  const { data, loading } = useQuery<OfferDetails, OfferDetailsVariables>(OFFER_DETAILS, {
+    variables: {
+      offerNumber,
+    },
+  });
+
   const [acceptOfferMutation] = useMutation<AcceptBerthSwitchOffer, AcceptBerthSwitchOfferVariables>(
     ACCEPT_BERTH_SWITCH_OFFER
   );
@@ -39,14 +39,13 @@ const BerthSwitchOfferPageContainer = ({ localePush }: Props) => {
     }).then(() => localePush('/offer-thank-you'));
   };
 
-  // TODO
-  // if (loading) return <LoadingPage />;
-  // const berthDetails = getOfferBerthDetails(data);
-  const berthDetails = {
-    harbor: '?',
-    pier: '?',
-    berth: '?',
-  };
+  if (loading) return <LoadingPage />;
+
+  const berthDetails = data?.offerDetails;
+
+  if (!berthDetails) {
+    return <GeneralOfferErrorPage />;
+  }
 
   return (
     <BerthSwitchOfferPage

--- a/src/features/berthSwitchOffer/offerError/GeneralOfferErrorPage.tsx
+++ b/src/features/berthSwitchOffer/offerError/GeneralOfferErrorPage.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from 'react-i18next';
+
+import NoticeTemplate, { NoticePageProps } from '../../../common/noticeTemplate/NoticeTemplate';
+
+export interface GeneralOfferErrorPageProps {
+  customMsg?: NoticePageProps['message'];
+}
+
+const GeneralOfferErrorPage = ({ customMsg }: GeneralOfferErrorPageProps) => {
+  const { t } = useTranslation();
+  return (
+    <NoticeTemplate
+      id={'vene-offer-general-error-page'}
+      titleText={t('page.offer_error.general_error.title')}
+      message={customMsg ?? <p>{t('page.offer_error.general_error.message')}</p>}
+    />
+  );
+};
+
+export default GeneralOfferErrorPage;

--- a/src/features/queries.ts
+++ b/src/features/queries.ts
@@ -312,17 +312,16 @@ export const CREATE_BERTH_PROFILE_MUTATION = gql`
   }
 `;
 
-// TODO
-// export const SWITCH_OFFER_DETAILS = gql`
-//   query SwitchOfferDetails($offerNumber: String!) {
-//     offerDetails(offerNumber: $offerNumber) {
-//       status
-//       harbor
-//       pier
-//       berth
-//     }
-//   }
-// `;
+export const OFFER_DETAILS = gql`
+  query OfferDetails($offerNumber: String!) {
+    offerDetails(offerNumber: $offerNumber) {
+      status
+      harbor
+      pier
+      berth
+    }
+  }
+`;
 
 export const MY_BOATS_QUERY = gql`
   query MyBoatsQuery {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -700,6 +700,12 @@
         "owner_information": "Owner information"
       }
     },
+    "offer_error": {
+      "general_error": {
+        "message": "We are sorry, but the offer could not be found. It may have been cancelled or the link may be invalid.",
+        "title": "Failure"
+      }
+    },
     "payment_error": {
       "already_paid": {
         "title": "All done!",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -708,6 +708,12 @@
         "owner_information": "Omistajan tiedot"
       }
     },
+    "offer_error": {
+      "general_error": {
+        "message": "Pahoittelemme, mutta ilmoitusta ei löydy. Se on voitu peruuttaa tai linkki voi olla virheellinen.",
+        "title": "Virhetilanne"
+      }
+    },
     "payment_error": {
       "already_paid": {
         "title": "Valmis!",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -700,6 +700,12 @@
         "owner_information": "Ägarens uppgifter"
       }
     },
+    "offer_error": {
+      "general_error": {
+        "message": "Vi kunde tyvärr inte hitta erbjudandet. Den kan ha annullerats, eller så kan länken vara felaktig.",
+        "title": "Fel"
+      }
+    },
     "payment_error": {
       "already_paid": {
         "title": "Färdig!",


### PR DESCRIPTION
VEN-1461. These berth details has been missing from the Berth switch offer page since the last big refactor.

This draft PR still needs the types, which can be generated when the open-city-profile directive issues are solved.