### PR TITLE
VEN-1418 | Allow any letter at the beginning of boat register number

### DIFF
--- a/src/common/utils/formValidation.ts
+++ b/src/common/utils/formValidation.ts
@@ -153,7 +153,7 @@ export const mustBeBusinessId = (value: string): string | undefined => {
 };
 
 export const mustBeBoatRegistrationNumber = (value: string): string | undefined => {
-  const regex = /^([PEL][0-9]{5,10})|([A-DF-KOQ-Z][0-9]{1,7})$/;
+  const regex = /^[A-ZÄÖÅ][1-9]{1,10}$/;
   if (regex.test(value)) {
     return undefined;
   }


### PR DESCRIPTION
## Description :sparkles:

Previously some letters were not allowed. After this change all letters + scandic letter Ä, Ö and Å are accepted. This also fixes issue where user was able to write as many letters in the beginning of the registration number, for example `adsaseawrdadcadA123123123`

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

