### PR TITLE
VEN-1503 | Allow 0 in boat registration numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Changed:**
 
 - Berth profile created on login if it did not previously exist
+- Allow boat registration numbers to contain 0
 </details>
 
 # 1.0.2 (October 28, 2020)

--- a/src/common/utils/__tests__/formValidation.test.ts
+++ b/src/common/utils/__tests__/formValidation.test.ts
@@ -191,6 +191,7 @@ describe('formValidation', () => {
       expect(mustBeBoatRegistrationNumber('A1')).toBeUndefined();
       expect(mustBeBoatRegistrationNumber('Z1234567')).toBeUndefined();
       expect(mustBeBoatRegistrationNumber('P12345')).toBeUndefined();
+      expect(mustBeBoatRegistrationNumber('P012345')).toBeUndefined();
     });
     test('should return an error message if number is invalid', () => {
       expect(mustBeBoatRegistrationNumber('P123123123321')).toEqual('validation.message.invalid_value');

--- a/src/common/utils/formValidation.ts
+++ b/src/common/utils/formValidation.ts
@@ -153,7 +153,7 @@ export const mustBeBusinessId = (value: string): string | undefined => {
 };
 
 export const mustBeBoatRegistrationNumber = (value: string): string | undefined => {
-  const regex = /^[A-ZÄÖÅ][1-9]{1,10}$/;
+  const regex = /^[A-ZÄÖÅ][0-9]{1,10}$/;
   if (regex.test(value)) {
     return undefined;
   }


### PR DESCRIPTION
## Description :sparkles:

Allow boat registration number to contain 0.

[VEN-1503](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1503)

