### PR TITLE
Show the GDPR -notes on every berth form wizard page

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,9 +92,10 @@
     "typescript": "^4.1.3"
   },
   "devDependencies": {
-    "@testing-library/react": "^11.2.5",
-    "@testing-library/testcafe": "^4.3.1",
-    "@testing-library/user-event": "^12.6.3",
+    "@testing-library/jest-dom": "^5.14.1",
+    "@testing-library/react": "^12.0.0",
+    "@testing-library/react-hooks": "^7.0.0",
+    "@testing-library/user-event": "^13.1.9",
     "@types/enzyme": "^3.10.8",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^26.0.0",

--- a/src/common/SrOnly/SrOnly.tsx
+++ b/src/common/SrOnly/SrOnly.tsx
@@ -1,0 +1,14 @@
+import classNames from 'classnames';
+import React from 'react';
+
+import styles from './srOnly.module.scss';
+interface Props {
+  as?: 'div' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span';
+  className?: string;
+}
+
+const SrOnly: React.FC<Props> = ({ as: Tag = 'div', children, className }) => {
+  return <Tag className={classNames(styles.srOnly, className)}>{children}</Tag>;
+};
+
+export default SrOnly;

--- a/src/common/SrOnly/__tests__/SrOnly.test.tsx
+++ b/src/common/SrOnly/__tests__/SrOnly.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import SrOnly from '../SrOnly';
+
+test('matches snapshot 1', () => {
+  const { container } = render(<SrOnly as="h1">Test</SrOnly>);
+
+  const srElement = screen.getByText('Test');
+  expect(srElement.tagName).toBe('H1');
+
+  expect(container).toMatchSnapshot();
+});
+
+test('matches snapshot 2', () => {
+  const { container } = render(<SrOnly as="h2">Test</SrOnly>);
+
+  const srElement = screen.getByText('Test');
+  expect(srElement.tagName).toBe('H2');
+
+  expect(container).toMatchSnapshot();
+});
+
+test('matches snapshot 3', () => {
+  const { container } = render(
+    <SrOnly className="testClass" as="span">
+      Test
+    </SrOnly>
+  );
+
+  const srElement = screen.getByText('Test');
+  expect(srElement.tagName).toBe('SPAN');
+
+  expect(srElement).toHaveClass('srOnly');
+  expect(srElement).toHaveClass('testClass');
+
+  expect(container).toMatchSnapshot();
+});

--- a/src/common/SrOnly/__tests__/__snapshots__/SrOnly.test.tsx.snap
+++ b/src/common/SrOnly/__tests__/__snapshots__/SrOnly.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`matches snapshot 1 1`] = `
+<div>
+  <h1
+    class="srOnly"
+  >
+    Test
+  </h1>
+</div>
+`;
+
+exports[`matches snapshot 2 1`] = `
+<div>
+  <h2
+    class="srOnly"
+  >
+    Test
+  </h2>
+</div>
+`;
+
+exports[`matches snapshot 3 1`] = `
+<div>
+  <span
+    class="srOnly testClass"
+  >
+    Test
+  </span>
+</div>
+`;

--- a/src/common/SrOnly/srOnly.module.scss
+++ b/src/common/SrOnly/srOnly.module.scss
@@ -1,0 +1,10 @@
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/src/common/agreement/PrivacyPoliciesAgreement.tsx
+++ b/src/common/agreement/PrivacyPoliciesAgreement.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Col, Row } from 'reactstrap';
+
+import { Checkbox } from '../fields/Fields';
+import styles from './privacyPoliciesAgreement.module.scss';
+
+interface Props {
+  label: JSX.Element;
+  gdprNotes: React.ReactNode;
+  colProps: object;
+}
+
+const PrivacyPoliciesAgreement = ({ label, gdprNotes, colProps }: Props) => (
+  <>
+    <Row className={styles.inputs}>
+      <Col {...colProps}>
+        <Checkbox name={`privacyPoliciesConfirmed`} label={label} required />
+      </Col>
+    </Row>
+    {gdprNotes && (
+      <Row className={styles.notes}>
+        <Col {...colProps}>{gdprNotes}</Col>
+      </Row>
+    )}
+  </>
+);
+
+export default PrivacyPoliciesAgreement;

--- a/src/common/agreement/PrivacyPoliciesAgreement.tsx
+++ b/src/common/agreement/PrivacyPoliciesAgreement.tsx
@@ -14,7 +14,7 @@ const PrivacyPoliciesAgreement = ({ label, gdprNotes, colProps }: Props) => (
   <>
     <Row className={styles.inputs}>
       <Col {...colProps}>
-        <Checkbox name={`privacyPoliciesConfirmed`} label={label} required />
+        <Checkbox name="privacyPoliciesConfirmed" label={label} required />
       </Col>
     </Row>
     {gdprNotes && (

--- a/src/common/agreement/privacyPoliciesAgreement.module.scss
+++ b/src/common/agreement/privacyPoliciesAgreement.module.scss
@@ -1,0 +1,5 @@
+.inputs {
+  div {
+    margin-bottom: 0 !important;
+  }
+}

--- a/src/common/externalLink/ExternalLink.tsx
+++ b/src/common/externalLink/ExternalLink.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import classNames from 'classnames';
+import { IconAngleRight, IconLinkExternal } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+
+import styles from './externalLink.module.scss';
+import SrOnly from '../SrOnly/SrOnly';
+
+export type ExternalLinkProps = {
+  children: React.ReactNode;
+  href: string;
+  target?: '_blank' | '_self';
+  variant?: 'default' | 'withArrow';
+};
+
+const ExternalLink = ({ variant = 'default', href, children, target = '_blank' }: ExternalLinkProps) => {
+  const { t } = useTranslation();
+  return (
+    <a className={classNames(styles.link, styles[variant])} href={href} target={target} rel="noopener noreferrer">
+      {children}
+      <i className={styles.icon}>
+        {variant === 'default' && <IconLinkExternal />}
+        {variant === 'withArrow' && <IconAngleRight />}
+      </i>
+      <SrOnly>{t('common.srOnly.opensInANewTab')}</SrOnly>
+    </a>
+  );
+};
+
+export default ExternalLink;

--- a/src/common/externalLink/__tests__/ExternalLink.test.tsx
+++ b/src/common/externalLink/__tests__/ExternalLink.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ExternalLink, { ExternalLinkProps } from '../ExternalLink';
+
+describe('ExternalLink', () => {
+  const getWrapper = (props: ExternalLinkProps) => shallow(<ExternalLink {...props} />);
+
+  it('renders normally', () => {
+    const wrapper = getWrapper({ children: 'test' });
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+});

--- a/src/common/externalLink/__tests__/__snapshots__/ExternalLink.test.tsx.snap
+++ b/src/common/externalLink/__tests__/__snapshots__/ExternalLink.test.tsx.snap
@@ -1,0 +1,574 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExternalLink renders normally 1`] = `
+initialize {
+  "0": Node {
+    "attribs": Object {
+      "class": "link default",
+      "rel": "noopener noreferrer",
+      "target": "_blank",
+    },
+    "children": Array [
+      Node {
+        "data": "test",
+        "next": Node {
+          "attribs": Object {
+            "class": "icon",
+          },
+          "children": Array [
+            Node {
+              "attribs": Object {
+                "class": "Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik",
+                "role": "img",
+                "viewBox": "0 0 24 24",
+                "xmlns": "http://www.w3.org/2000/svg",
+              },
+              "children": Array [
+                Node {
+                  "attribs": Object {
+                    "fill": "none",
+                    "fill-rule": "evenodd",
+                  },
+                  "children": Array [
+                    Node {
+                      "attribs": Object {
+                        "d": "M0 0h24v24H0z",
+                      },
+                      "children": Array [],
+                      "name": "path",
+                      "namespace": "http://www.w3.org/2000/svg",
+                      "next": Node {
+                        "attribs": Object {
+                          "d": "M10 3v2H5v14h14v-5h2v7H3V3h7zm11 0v8h-2V6.413l-7 7.001L10.586 12l6.999-7H13V3h8z",
+                          "fill": "currentColor",
+                        },
+                        "children": Array [],
+                        "name": "path",
+                        "namespace": "http://www.w3.org/2000/svg",
+                        "next": null,
+                        "parent": [Circular],
+                        "prev": [Circular],
+                        "type": "tag",
+                        "x-attribsNamespace": Object {
+                          "d": undefined,
+                          "fill": undefined,
+                        },
+                        "x-attribsPrefix": Object {
+                          "d": undefined,
+                          "fill": undefined,
+                        },
+                      },
+                      "parent": [Circular],
+                      "prev": null,
+                      "type": "tag",
+                      "x-attribsNamespace": Object {
+                        "d": undefined,
+                      },
+                      "x-attribsPrefix": Object {
+                        "d": undefined,
+                      },
+                    },
+                    Node {
+                      "attribs": Object {
+                        "d": "M10 3v2H5v14h14v-5h2v7H3V3h7zm11 0v8h-2V6.413l-7 7.001L10.586 12l6.999-7H13V3h8z",
+                        "fill": "currentColor",
+                      },
+                      "children": Array [],
+                      "name": "path",
+                      "namespace": "http://www.w3.org/2000/svg",
+                      "next": null,
+                      "parent": [Circular],
+                      "prev": Node {
+                        "attribs": Object {
+                          "d": "M0 0h24v24H0z",
+                        },
+                        "children": Array [],
+                        "name": "path",
+                        "namespace": "http://www.w3.org/2000/svg",
+                        "next": [Circular],
+                        "parent": [Circular],
+                        "prev": null,
+                        "type": "tag",
+                        "x-attribsNamespace": Object {
+                          "d": undefined,
+                        },
+                        "x-attribsPrefix": Object {
+                          "d": undefined,
+                        },
+                      },
+                      "type": "tag",
+                      "x-attribsNamespace": Object {
+                        "d": undefined,
+                        "fill": undefined,
+                      },
+                      "x-attribsPrefix": Object {
+                        "d": undefined,
+                        "fill": undefined,
+                      },
+                    },
+                  ],
+                  "name": "g",
+                  "namespace": "http://www.w3.org/2000/svg",
+                  "next": null,
+                  "parent": [Circular],
+                  "prev": null,
+                  "type": "tag",
+                  "x-attribsNamespace": Object {
+                    "fill": undefined,
+                    "fill-rule": undefined,
+                  },
+                  "x-attribsPrefix": Object {
+                    "fill": undefined,
+                    "fill-rule": undefined,
+                  },
+                },
+              ],
+              "name": "svg",
+              "namespace": "http://www.w3.org/2000/svg",
+              "next": null,
+              "parent": [Circular],
+              "prev": null,
+              "type": "tag",
+              "x-attribsNamespace": Object {
+                "class": undefined,
+                "role": undefined,
+                "viewBox": undefined,
+                "xmlns": "http://www.w3.org/2000/xmlns/",
+              },
+              "x-attribsPrefix": Object {
+                "class": undefined,
+                "role": undefined,
+                "viewBox": undefined,
+                "xmlns": "",
+              },
+            },
+          ],
+          "name": "i",
+          "namespace": "http://www.w3.org/1999/xhtml",
+          "next": Node {
+            "attribs": Object {
+              "class": "srOnly",
+            },
+            "children": Array [
+              Node {
+                "data": "Avautuu uudessa välilehdessä",
+                "next": null,
+                "parent": [Circular],
+                "prev": null,
+                "type": "text",
+              },
+            ],
+            "name": "div",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "next": null,
+            "parent": [Circular],
+            "prev": [Circular],
+            "type": "tag",
+            "x-attribsNamespace": Object {
+              "class": undefined,
+            },
+            "x-attribsPrefix": Object {
+              "class": undefined,
+            },
+          },
+          "parent": [Circular],
+          "prev": [Circular],
+          "type": "tag",
+          "x-attribsNamespace": Object {
+            "class": undefined,
+          },
+          "x-attribsPrefix": Object {
+            "class": undefined,
+          },
+        },
+        "parent": [Circular],
+        "prev": null,
+        "type": "text",
+      },
+      Node {
+        "attribs": Object {
+          "class": "icon",
+        },
+        "children": Array [
+          Node {
+            "attribs": Object {
+              "class": "Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik",
+              "role": "img",
+              "viewBox": "0 0 24 24",
+              "xmlns": "http://www.w3.org/2000/svg",
+            },
+            "children": Array [
+              Node {
+                "attribs": Object {
+                  "fill": "none",
+                  "fill-rule": "evenodd",
+                },
+                "children": Array [
+                  Node {
+                    "attribs": Object {
+                      "d": "M0 0h24v24H0z",
+                    },
+                    "children": Array [],
+                    "name": "path",
+                    "namespace": "http://www.w3.org/2000/svg",
+                    "next": Node {
+                      "attribs": Object {
+                        "d": "M10 3v2H5v14h14v-5h2v7H3V3h7zm11 0v8h-2V6.413l-7 7.001L10.586 12l6.999-7H13V3h8z",
+                        "fill": "currentColor",
+                      },
+                      "children": Array [],
+                      "name": "path",
+                      "namespace": "http://www.w3.org/2000/svg",
+                      "next": null,
+                      "parent": [Circular],
+                      "prev": [Circular],
+                      "type": "tag",
+                      "x-attribsNamespace": Object {
+                        "d": undefined,
+                        "fill": undefined,
+                      },
+                      "x-attribsPrefix": Object {
+                        "d": undefined,
+                        "fill": undefined,
+                      },
+                    },
+                    "parent": [Circular],
+                    "prev": null,
+                    "type": "tag",
+                    "x-attribsNamespace": Object {
+                      "d": undefined,
+                    },
+                    "x-attribsPrefix": Object {
+                      "d": undefined,
+                    },
+                  },
+                  Node {
+                    "attribs": Object {
+                      "d": "M10 3v2H5v14h14v-5h2v7H3V3h7zm11 0v8h-2V6.413l-7 7.001L10.586 12l6.999-7H13V3h8z",
+                      "fill": "currentColor",
+                    },
+                    "children": Array [],
+                    "name": "path",
+                    "namespace": "http://www.w3.org/2000/svg",
+                    "next": null,
+                    "parent": [Circular],
+                    "prev": Node {
+                      "attribs": Object {
+                        "d": "M0 0h24v24H0z",
+                      },
+                      "children": Array [],
+                      "name": "path",
+                      "namespace": "http://www.w3.org/2000/svg",
+                      "next": [Circular],
+                      "parent": [Circular],
+                      "prev": null,
+                      "type": "tag",
+                      "x-attribsNamespace": Object {
+                        "d": undefined,
+                      },
+                      "x-attribsPrefix": Object {
+                        "d": undefined,
+                      },
+                    },
+                    "type": "tag",
+                    "x-attribsNamespace": Object {
+                      "d": undefined,
+                      "fill": undefined,
+                    },
+                    "x-attribsPrefix": Object {
+                      "d": undefined,
+                      "fill": undefined,
+                    },
+                  },
+                ],
+                "name": "g",
+                "namespace": "http://www.w3.org/2000/svg",
+                "next": null,
+                "parent": [Circular],
+                "prev": null,
+                "type": "tag",
+                "x-attribsNamespace": Object {
+                  "fill": undefined,
+                  "fill-rule": undefined,
+                },
+                "x-attribsPrefix": Object {
+                  "fill": undefined,
+                  "fill-rule": undefined,
+                },
+              },
+            ],
+            "name": "svg",
+            "namespace": "http://www.w3.org/2000/svg",
+            "next": null,
+            "parent": [Circular],
+            "prev": null,
+            "type": "tag",
+            "x-attribsNamespace": Object {
+              "class": undefined,
+              "role": undefined,
+              "viewBox": undefined,
+              "xmlns": "http://www.w3.org/2000/xmlns/",
+            },
+            "x-attribsPrefix": Object {
+              "class": undefined,
+              "role": undefined,
+              "viewBox": undefined,
+              "xmlns": "",
+            },
+          },
+        ],
+        "name": "i",
+        "namespace": "http://www.w3.org/1999/xhtml",
+        "next": Node {
+          "attribs": Object {
+            "class": "srOnly",
+          },
+          "children": Array [
+            Node {
+              "data": "Avautuu uudessa välilehdessä",
+              "next": null,
+              "parent": [Circular],
+              "prev": null,
+              "type": "text",
+            },
+          ],
+          "name": "div",
+          "namespace": "http://www.w3.org/1999/xhtml",
+          "next": null,
+          "parent": [Circular],
+          "prev": [Circular],
+          "type": "tag",
+          "x-attribsNamespace": Object {
+            "class": undefined,
+          },
+          "x-attribsPrefix": Object {
+            "class": undefined,
+          },
+        },
+        "parent": [Circular],
+        "prev": Node {
+          "data": "test",
+          "next": [Circular],
+          "parent": [Circular],
+          "prev": null,
+          "type": "text",
+        },
+        "type": "tag",
+        "x-attribsNamespace": Object {
+          "class": undefined,
+        },
+        "x-attribsPrefix": Object {
+          "class": undefined,
+        },
+      },
+      Node {
+        "attribs": Object {
+          "class": "srOnly",
+        },
+        "children": Array [
+          Node {
+            "data": "Avautuu uudessa välilehdessä",
+            "next": null,
+            "parent": [Circular],
+            "prev": null,
+            "type": "text",
+          },
+        ],
+        "name": "div",
+        "namespace": "http://www.w3.org/1999/xhtml",
+        "next": null,
+        "parent": [Circular],
+        "prev": Node {
+          "attribs": Object {
+            "class": "icon",
+          },
+          "children": Array [
+            Node {
+              "attribs": Object {
+                "class": "Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik",
+                "role": "img",
+                "viewBox": "0 0 24 24",
+                "xmlns": "http://www.w3.org/2000/svg",
+              },
+              "children": Array [
+                Node {
+                  "attribs": Object {
+                    "fill": "none",
+                    "fill-rule": "evenodd",
+                  },
+                  "children": Array [
+                    Node {
+                      "attribs": Object {
+                        "d": "M0 0h24v24H0z",
+                      },
+                      "children": Array [],
+                      "name": "path",
+                      "namespace": "http://www.w3.org/2000/svg",
+                      "next": Node {
+                        "attribs": Object {
+                          "d": "M10 3v2H5v14h14v-5h2v7H3V3h7zm11 0v8h-2V6.413l-7 7.001L10.586 12l6.999-7H13V3h8z",
+                          "fill": "currentColor",
+                        },
+                        "children": Array [],
+                        "name": "path",
+                        "namespace": "http://www.w3.org/2000/svg",
+                        "next": null,
+                        "parent": [Circular],
+                        "prev": [Circular],
+                        "type": "tag",
+                        "x-attribsNamespace": Object {
+                          "d": undefined,
+                          "fill": undefined,
+                        },
+                        "x-attribsPrefix": Object {
+                          "d": undefined,
+                          "fill": undefined,
+                        },
+                      },
+                      "parent": [Circular],
+                      "prev": null,
+                      "type": "tag",
+                      "x-attribsNamespace": Object {
+                        "d": undefined,
+                      },
+                      "x-attribsPrefix": Object {
+                        "d": undefined,
+                      },
+                    },
+                    Node {
+                      "attribs": Object {
+                        "d": "M10 3v2H5v14h14v-5h2v7H3V3h7zm11 0v8h-2V6.413l-7 7.001L10.586 12l6.999-7H13V3h8z",
+                        "fill": "currentColor",
+                      },
+                      "children": Array [],
+                      "name": "path",
+                      "namespace": "http://www.w3.org/2000/svg",
+                      "next": null,
+                      "parent": [Circular],
+                      "prev": Node {
+                        "attribs": Object {
+                          "d": "M0 0h24v24H0z",
+                        },
+                        "children": Array [],
+                        "name": "path",
+                        "namespace": "http://www.w3.org/2000/svg",
+                        "next": [Circular],
+                        "parent": [Circular],
+                        "prev": null,
+                        "type": "tag",
+                        "x-attribsNamespace": Object {
+                          "d": undefined,
+                        },
+                        "x-attribsPrefix": Object {
+                          "d": undefined,
+                        },
+                      },
+                      "type": "tag",
+                      "x-attribsNamespace": Object {
+                        "d": undefined,
+                        "fill": undefined,
+                      },
+                      "x-attribsPrefix": Object {
+                        "d": undefined,
+                        "fill": undefined,
+                      },
+                    },
+                  ],
+                  "name": "g",
+                  "namespace": "http://www.w3.org/2000/svg",
+                  "next": null,
+                  "parent": [Circular],
+                  "prev": null,
+                  "type": "tag",
+                  "x-attribsNamespace": Object {
+                    "fill": undefined,
+                    "fill-rule": undefined,
+                  },
+                  "x-attribsPrefix": Object {
+                    "fill": undefined,
+                    "fill-rule": undefined,
+                  },
+                },
+              ],
+              "name": "svg",
+              "namespace": "http://www.w3.org/2000/svg",
+              "next": null,
+              "parent": [Circular],
+              "prev": null,
+              "type": "tag",
+              "x-attribsNamespace": Object {
+                "class": undefined,
+                "role": undefined,
+                "viewBox": undefined,
+                "xmlns": "http://www.w3.org/2000/xmlns/",
+              },
+              "x-attribsPrefix": Object {
+                "class": undefined,
+                "role": undefined,
+                "viewBox": undefined,
+                "xmlns": "",
+              },
+            },
+          ],
+          "name": "i",
+          "namespace": "http://www.w3.org/1999/xhtml",
+          "next": [Circular],
+          "parent": [Circular],
+          "prev": Node {
+            "data": "test",
+            "next": [Circular],
+            "parent": [Circular],
+            "prev": null,
+            "type": "text",
+          },
+          "type": "tag",
+          "x-attribsNamespace": Object {
+            "class": undefined,
+          },
+          "x-attribsPrefix": Object {
+            "class": undefined,
+          },
+        },
+        "type": "tag",
+        "x-attribsNamespace": Object {
+          "class": undefined,
+        },
+        "x-attribsPrefix": Object {
+          "class": undefined,
+        },
+      },
+    ],
+    "name": "a",
+    "namespace": "http://www.w3.org/1999/xhtml",
+    "next": null,
+    "parent": Node {
+      "children": Array [
+        [Circular],
+      ],
+      "name": "root",
+      "next": null,
+      "parent": null,
+      "prev": null,
+      "type": "root",
+    },
+    "prev": null,
+    "type": "tag",
+    "x-attribsNamespace": Object {
+      "class": undefined,
+      "rel": undefined,
+      "target": undefined,
+    },
+    "x-attribsPrefix": Object {
+      "class": undefined,
+      "rel": undefined,
+      "target": undefined,
+    },
+  },
+  "_root": [Circular],
+  "length": 1,
+  "options": Object {
+    "decodeEntities": true,
+    "xml": false,
+  },
+}
+`;

--- a/src/common/externalLink/externalLink.module.scss
+++ b/src/common/externalLink/externalLink.module.scss
@@ -1,0 +1,4 @@
+.icon {
+  --icon-size: 1em;
+  margin-left: var(--spacing-3-xs);
+}

--- a/src/common/form/Form.tsx
+++ b/src/common/form/Form.tsx
@@ -7,13 +7,15 @@ interface Props {
   onSubmit: Function;
   initialValues: object;
   children: (props: any) => React.ReactNode;
+  className?: string;
 }
 
-const Form = ({ onSubmit, initialValues, children }: Props) => {
+const Form = ({ onSubmit, initialValues, children, className }: Props) => {
   const { i18n } = useTranslation();
 
   return (
     <FinalForm
+      className={className}
       onSubmit={(formData) => onSubmit(formData)}
       initialValues={{ ...initialValues, language: i18n.language }}
       render={({ handleSubmit, ...renderProps }) => (

--- a/src/common/formPage/FormPage.tsx
+++ b/src/common/formPage/FormPage.tsx
@@ -12,6 +12,7 @@ import './formPage.scss';
 
 interface Props {
   children: React.ReactNode;
+  gdprNotes?: React.ReactNode;
   currentStep: number;
   goBackward: Function;
   goForward: Function;
@@ -24,6 +25,7 @@ interface Props {
 
 const FormPage = ({
   children,
+  gdprNotes,
   currentStep,
   goBackward,
   goForward,
@@ -58,6 +60,7 @@ const FormPage = ({
           steps={steps}
           stepsBeforeForm={stepsBeforeForm}
           submit={submit}
+          gdprNotes={gdprNotes}
         >
           {children}
         </Wizard>

--- a/src/common/wizard/Wizard.tsx
+++ b/src/common/wizard/Wizard.tsx
@@ -115,7 +115,7 @@ const Wizard = ({
   return (
     <Form initialValues={initialValues} onSubmit={handleSubmit}>
       {({ invalid, values }: { invalid: boolean; values: {} }) => (
-        <div className={`${!!gdprNotes ? 'vene-form-container__without-bottom-margin' : 'vene-form-container'}`}>
+        <div className={`vene-form-container${!!gdprNotes && '__without-bottom-margin'}`}>
           {React.isValidElement(formContentComponent) &&
             React.cloneElement<{ values?: {} }>(formContentComponent, { values })}
           {!!gdprNotes && (

--- a/src/common/wizard/Wizard.tsx
+++ b/src/common/wizard/Wizard.tsx
@@ -8,9 +8,11 @@ import Form from '../form/Form';
 import { StepType } from '../steps/step/Step';
 import { WinterStorageMethod } from '../../__generated__/globalTypes';
 import './wizard.scss';
+import PrivacyPoliciesAgreement from '../agreement/PrivacyPoliciesAgreement';
 
 type Props = {
   children: React.ReactNode;
+  gdprNotes?: React.ReactNode;
   currentStep: number;
   goBackward: Function;
   goForward: Function;
@@ -26,6 +28,7 @@ type Props = {
 
 const Wizard = ({
   children,
+  gdprNotes,
   currentStep,
   goBackward,
   goForward,
@@ -105,14 +108,35 @@ const Wizard = ({
 
   const formContentComponent = React.Children.toArray(children)[0];
 
+  const confirmGdprPrivacyPolicies = isLastFormStep(currentStep);
+  const gdprColProps = { lg: { size: 10, offset: 1 }, xl: { size: 8, offset: 2 } };
   // FIXME
   /* eslint-disable react/no-unused-prop-types */
   return (
     <Form initialValues={initialValues} onSubmit={handleSubmit}>
       {({ invalid, values }: { invalid: boolean; values: {} }) => (
-        <>
+        <div className={`${!!gdprNotes ? 'vene-form-container__without-bottom-margin' : 'vene-form-container'}`}>
           {React.isValidElement(formContentComponent) &&
             React.cloneElement<{ values?: {} }>(formContentComponent, { values })}
+          {!!gdprNotes && (
+            <Container>
+              {confirmGdprPrivacyPolicies ? (
+                <PrivacyPoliciesAgreement
+                  colProps={gdprColProps}
+                  label={
+                    <span className="vene-formfield__label is-required">
+                      {t('form.gdpr.privacyPoliciesAgreement.label')}
+                    </span>
+                  }
+                  gdprNotes={gdprNotes}
+                />
+              ) : (
+                <Row>
+                  <Col {...gdprColProps}>{gdprNotes}</Col>
+                </Row>
+              )}
+            </Container>
+          )}
           <div className="vene-form__wizard-wrapper">
             <Container>
               <Row>
@@ -127,7 +151,7 @@ const Wizard = ({
               </Row>
             </Container>
           </div>
-        </>
+        </div>
       )}
     </Form>
   );

--- a/src/common/wizard/wizard.scss
+++ b/src/common/wizard/wizard.scss
@@ -26,3 +26,12 @@
     }
   }
 }
+
+/* Removes the bottom margin when gdpr notes are shown in the bottom of the wizard */
+.vene-form-container {
+  &__without-bottom-margin {
+    .vene-form__styled-container {
+      margin-bottom: 0 !important;
+    }
+  }
+}

--- a/src/features/berth/berthFormPage/BerthFormPageContainer.tsx
+++ b/src/features/berth/berthFormPage/BerthFormPageContainer.tsx
@@ -34,6 +34,7 @@ import { getCurrentBerths, getReasonOptions } from './switchApplication/utils';
 import { ProfilePageQuery } from '../../__generated__/ProfilePageQuery';
 import { getFormValuesFromProfile } from '../../profile/utils';
 import { MyBoatsQuery } from '../../__generated__/MyBoatsQuery';
+import GdprNotes from './boatDetails/createBerthBoat/tabs/fragments/GdprNotes';
 
 type Props = {
   applicationType: ApplicationOptions;
@@ -231,6 +232,7 @@ const BerthFormPageContainer = ({
       stepsBeforeForm={stepsBeforeForm}
       submit={submit}
       loading={profilePageQuery.loading}
+      gdprNotes={<GdprNotes />}
       {...rest}
     >
       {getStepComponent()}

--- a/src/features/berth/berthFormPage/boatDetails/createBerthBoat/tabs/BerthRegisteredBoat.tsx
+++ b/src/features/berth/berthFormPage/boatDetails/createBerthBoat/tabs/BerthRegisteredBoat.tsx
@@ -7,6 +7,7 @@ import BoatInfoFragment from '../../../../../../common/boatInfoFragment/BoatInfo
 import BoatMeasures from '../../../../../../common/boatMeasuresFragment/BoatMeasuresFragment';
 import RegisteredBoatDetails from '../../../../../../common/registeredBoatDetails/RegisteredBoatDetails';
 import { WithBoatType } from '../../../../../../common/selects/Selects';
+import GdprNotes from './fragments/GdprNotes';
 
 type Props = {
   showBigShipsForm: boolean;
@@ -29,6 +30,7 @@ const BerthRegisteredBoat = ({ showBigShipsForm, boatTypes }: Props) => {
       )}
       <BoatInfoFragment />
       <Accessibility />
+      <GdprNotes />
     </FormTab>
   );
 };

--- a/src/features/berth/berthFormPage/boatDetails/createBerthBoat/tabs/BerthRegisteredBoat.tsx
+++ b/src/features/berth/berthFormPage/boatDetails/createBerthBoat/tabs/BerthRegisteredBoat.tsx
@@ -7,7 +7,6 @@ import BoatInfoFragment from '../../../../../../common/boatInfoFragment/BoatInfo
 import BoatMeasures from '../../../../../../common/boatMeasuresFragment/BoatMeasuresFragment';
 import RegisteredBoatDetails from '../../../../../../common/registeredBoatDetails/RegisteredBoatDetails';
 import { WithBoatType } from '../../../../../../common/selects/Selects';
-import GdprNotes from './fragments/GdprNotes';
 
 type Props = {
   showBigShipsForm: boolean;
@@ -30,7 +29,6 @@ const BerthRegisteredBoat = ({ showBigShipsForm, boatTypes }: Props) => {
       )}
       <BoatInfoFragment />
       <Accessibility />
-      <GdprNotes />
     </FormTab>
   );
 };

--- a/src/features/berth/berthFormPage/boatDetails/createBerthBoat/tabs/fragments/GdprNotes.tsx
+++ b/src/features/berth/berthFormPage/boatDetails/createBerthBoat/tabs/fragments/GdprNotes.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import ExternalLink from '../../../../../../../common/externalLink/ExternalLink';
+import styles from './gdprNotes.module.scss';
+
+const GdprNotes = () => {
+  const { t } = useTranslation();
+  return (
+    <div className={styles.container}>
+      <a href={t('site.footer.url.terms_of_service')} rel="noopener noreferrer" target="_blank">
+        {t('form.gdpr.berthPrivacyStatementLink.text')}
+      </a>
+
+      <ExternalLink href={t('form.gdpr.openCityProfilePrivacyStatementLink.url')}>
+        {t('form.gdpr.openCityProfilePrivacyStatementLink.text')}
+      </ExternalLink>
+
+      <ExternalLink href={t('form.gdpr.cityOfHelsinkiPrivacyStatementLink.url')}>
+        {t('form.gdpr.cityOfHelsinkiPrivacyStatementLink.text')}
+      </ExternalLink>
+    </div>
+  );
+};
+
+export default GdprNotes;

--- a/src/features/berth/berthFormPage/boatDetails/createBerthBoat/tabs/fragments/gdprNotes.module.scss
+++ b/src/features/berth/berthFormPage/boatDetails/createBerthBoat/tabs/fragments/gdprNotes.module.scss
@@ -1,0 +1,7 @@
+.container {
+  margin-top: var(--spacing-xl);
+  & > a {
+    display: block;
+    margin: var(--spacing-s) 0;
+  }
+}

--- a/src/features/berth/berthFormPage/boatDetails/createBerthBoat/tabs/fragments/gdprNotes.module.scss
+++ b/src/features/berth/berthFormPage/boatDetails/createBerthBoat/tabs/fragments/gdprNotes.module.scss
@@ -1,5 +1,5 @@
 .container {
-  margin-top: var(--spacing-xl);
+  margin-bottom: var(--spacing-xl);
   & > a {
     display: block;
     margin: var(--spacing-s) 0;

--- a/src/features/berth/berthFormPage/overview/BerthOverview.tsx
+++ b/src/features/berth/berthFormPage/overview/BerthOverview.tsx
@@ -36,7 +36,13 @@ const BerthOverview = ({ boatTab, boatTypes, selectedHarbors, steps, values }: P
             <h5>{t('form.overview.header.receivable_items.title')}</h5>
             <Newsletter />
             <h3>{t('form.overview.header.agreement.title')}</h3>
-            <Agreement label={<span>{t('form.overview.field.berth.guarantee.label')}</span>} />
+            <Agreement
+              label={
+                <span className="vene-formfield__label is-required">
+                  {t('form.overview.field.berth.guarantee.label')}
+                </span>
+              }
+            />
           </div>
         </Col>
       </Row>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -66,6 +66,9 @@
       "cityOfHelsinkiPrivacyStatementLink": {
         "text": "The privacy policy of the city of Helsinki",
         "url": "#"
+      },
+      "privacyPoliciesAgreement": {
+        "label": "I have read and agree to the following documents:"
       }
     },
     "accessibility": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -57,15 +57,16 @@
   "form": {
     "gdpr": {
       "berthPrivacyStatementLink": {
-        "text": "Berth reservation's privacy policy (pdf)"
+        "text": "Berth reservation's privacy policy (pdf)",
+        "url": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Kuva/Kuva-EU-Venepaikkojen-varausrekisteri.pdf"
       },
       "openCityProfilePrivacyStatementLink": {
-        "text": "Helsinki-profile's privacy policy",
-        "url": "#"
+        "text": "Helsinki-profile's privacy policy (pdf)",
+        "url": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Sahkoisten%20asiointipalveluiden%20rekisteri.pdf"
       },
       "cityOfHelsinkiPrivacyStatementLink": {
         "text": "The privacy policy of the city of Helsinki",
-        "url": "#"
+        "url": "https://www.hel.fi/helsinki/en/administration/information/data-protection/"
       },
       "privacyPoliciesAgreement": {
         "label": "I have read and agree to the following documents:"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -41,6 +41,9 @@
       "FINNISH": "Finnish",
       "ENGLISH": "English",
       "SWEDISH": "Swedish"
+    },
+    "srOnly": {
+      "opensInANewTab": "Opens in a new tab"
     }
   },
   "error": {
@@ -52,6 +55,19 @@
     }
   },
   "form": {
+    "gdpr": {
+      "berthPrivacyStatementLink": {
+        "text": "Berth reservation's privacy policy (pdf)"
+      },
+      "openCityProfilePrivacyStatementLink": {
+        "text": "Helsinki-profile's privacy policy",
+        "url": "#"
+      },
+      "cityOfHelsinkiPrivacyStatementLink": {
+        "text": "The privacy policy of the city of Helsinki",
+        "url": "#"
+      }
+    },
     "accessibility": {
       "field": {
         "accessibility": {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -58,15 +58,16 @@
   "form": {
     "gdpr": {
       "berthPrivacyStatementLink": {
-        "text": "Venepaikkojen rekisteriseloste (pdf)"
+        "text": "Venepaikkojen rekisteriseloste (pdf)",
+        "url": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Kuva/Kuva-EU-Venepaikkojen-varausrekisteri.pdf"
       },
       "openCityProfilePrivacyStatementLink": {
-        "text": "Helsinki-profiilin rekisteriseloste",
-        "url": "#"
+        "text": "Helsinki-profiilin rekisteriseloste (pdf)",
+        "url": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Sahkoisten%20asiointipalveluiden%20rekisteri.pdf"
       },
       "cityOfHelsinkiPrivacyStatementLink": {
         "text": "Helsingin kaupungin tietosuojakäytäntö",
-        "url": "#"
+        "url": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/"
       },
       "privacyPoliciesAgreement": {
         "label": "Olen tutustunut seuraaviin dokumentteihin ja hyväksyn tietojeni käytön niiden mukaisesti:"

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -67,6 +67,9 @@
       "cityOfHelsinkiPrivacyStatementLink": {
         "text": "Helsingin kaupungin tietosuojakäytäntö",
         "url": "#"
+      },
+      "privacyPoliciesAgreement": {
+        "label": "Olen tutustunut seuraaviin dokumentteihin ja hyväksyn tietojeni käytön niiden mukaisesti:"
       }
     },
     "accessibility": {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -42,6 +42,9 @@
       "FINNISH": "suomi",
       "ENGLISH": "englanti",
       "SWEDISH": "ruotsi"
+    },
+    "srOnly": {
+      "opensInANewTab": "Avautuu uudessa välilehdessä"
     }
   },
   "error": {
@@ -53,6 +56,19 @@
     }
   },
   "form": {
+    "gdpr": {
+      "berthPrivacyStatementLink": {
+        "text": "Venepaikkojen rekisteriseloste (pdf)"
+      },
+      "openCityProfilePrivacyStatementLink": {
+        "text": "Helsinki-profiilin rekisteriseloste",
+        "url": "#"
+      },
+      "cityOfHelsinkiPrivacyStatementLink": {
+        "text": "Helsingin kaupungin tietosuojakäytäntö",
+        "url": "#"
+      }
+    },
     "accessibility": {
       "field": {
         "accessibility": {

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -54,15 +54,16 @@
   "form": {
     "gdpr": {
       "berthPrivacyStatementLink": {
-        "text": "Båtplatsers integritetspolicy (pdf)"
+        "text": "Båtplatsers integritetspolicy (pdf)",
+        "url": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Kuva/Kuva-EU-Venepaikkojen-varausrekisteri-SV.pdf"
       },
       "openCityProfilePrivacyStatementLink": {
-        "text": "Helsingfors-profilens integritetspolicy",
-        "url": "#"
+        "text": "Helsingfors-profilens integritetspolicy (pdf)",
+        "url": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Register%20over%20e-tjanster.pdf"
       },
       "cityOfHelsinkiPrivacyStatementLink": {
         "text": "Helsingfors stads integritetspolicy",
-        "url": "#"
+        "url": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/information/dataskydd"
       },
       "privacyPoliciesAgreement": {
         "label": "Jag har läst och godkänner följande dokument:"

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -4,7 +4,7 @@
     "area": "Området",
     "berth": "Båtplatsen",
     "cancelled": "Annullerat",
-    "data_missing_query_error": "SV: Tietojen lataamisesa tapahtui virhe",
+    "data_missing_query_error": "Det gick inte att läsa in data",
     "dinghy_place": "Jolleplats",
     "drafted": "Erbjuden",
     "due_date": "Förfallodatum",
@@ -52,6 +52,22 @@
     }
   },
   "form": {
+    "gdpr": {
+      "berthPrivacyStatementLink": {
+        "text": "Båtplatsers integritetspolicy (pdf)"
+      },
+      "openCityProfilePrivacyStatementLink": {
+        "text": "Helsingfors-profilens integritetspolicy",
+        "url": "#"
+      },
+      "cityOfHelsinkiPrivacyStatementLink": {
+        "text": "Helsingfors stads integritetspolicy",
+        "url": "#"
+      },
+      "privacyPoliciesAgreement": {
+        "label": "Jag har läst och godkänner följande dokument:"
+      }
+    },
     "accessibility": {
       "field": {
         "accessibility": {
@@ -299,11 +315,11 @@
     },
     "registered": {
       "action": {
-        "intent_to_create_boat": "SV: Lisää uusi vene"
+        "intent_to_create_boat": "Lägg till en ny båt"
       },
       "field": {
         "boat_id": {
-          "label": "SV: Vene"
+          "label": "Båt"
         },
         "draught": {
           "label": "Båtens djup",

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom/extend-expect';
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1259,6 +1259,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.9.2":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.7", "@babel/template@^7.3.3":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.7.tgz#c817233696018e39fbb6c491d2fb684e05ed43bc"
@@ -2143,53 +2150,59 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
-"@testing-library/dom@^7.27.1":
-  version "7.29.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.29.2.tgz#6cba65d961d8b36d621a98caa8537444075fb42e"
-  integrity sha512-CBMELfyY1jKdtLcSRmEnZWRzRkCRVSNPTzhzrn8wY8OnzUo7Pe/W+HgLzt4TDnWIPYeusHBodf9wUjJF48kPmA==
+"@testing-library/dom@^8.0.0":
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.13.0.tgz#bc00bdd64c7d8b40841e27a70211399ad3af46f5"
+  integrity sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
     "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
+    aria-query "^5.0.0"
     chalk "^4.1.0"
-    dom-accessibility-api "^0.5.4"
+    dom-accessibility-api "^0.5.9"
     lz-string "^1.4.4"
-    pretty-format "^26.6.2"
+    pretty-format "^27.0.2"
 
-"@testing-library/dom@^7.28.1":
-  version "7.29.4"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.29.4.tgz#1647c2b478789621ead7a50614ad81ab5ae5b86c"
-  integrity sha512-CtrJRiSYEfbtNGtEsd78mk1n1v2TUbeABlNIcOCJdDfkN5/JTOwQEbbQpoSRxGqzcWPgStMvJ4mNolSuBRv1NA==
+"@testing-library/jest-dom@^5.14.1":
+  version "5.16.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.16.4.tgz#938302d7b8b483963a3ae821f1c0808f872245cd"
+  integrity sha512-Gy+IoFutbMQcky0k+bqqumXZ1cTGswLsFqmNLzNdSKkU9KGV2u9oXhukCbbJ9/LRPKiqwxEE8VpV/+YZlfkPUA==
   dependencies:
-    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^5.0.0"
+    chalk "^3.0.0"
+    css "^3.0.0"
+    css.escape "^1.5.1"
+    dom-accessibility-api "^0.5.6"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
+"@testing-library/react-hooks@^7.0.0":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz#3388d07f562d91e7f2431a4a21b5186062ecfee0"
+  integrity sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==
+  dependencies:
     "@babel/runtime" "^7.12.5"
-    "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
-    chalk "^4.1.0"
-    dom-accessibility-api "^0.5.4"
-    lz-string "^1.4.4"
-    pretty-format "^26.6.2"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    react-error-boundary "^3.1.0"
 
-"@testing-library/react@^11.2.5":
-  version "11.2.5"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.5.tgz#ae1c36a66c7790ddb6662c416c27863d87818eb9"
-  integrity sha512-yEx7oIa/UWLe2F2dqK0FtMF9sJWNXD+2PPtp39BvE0Kh9MJ9Kl0HrZAgEuhUJR+Lx8Di6Xz+rKwSdEPY2UV8ZQ==
+"@testing-library/react@^12.0.0":
+  version "12.1.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
+  integrity sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^7.28.1"
+    "@testing-library/dom" "^8.0.0"
+    "@types/react-dom" "<18.0.0"
 
-"@testing-library/testcafe@^4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/testcafe/-/testcafe-4.3.1.tgz#327b401381ca019828b58beb9621dd58695393ee"
-  integrity sha512-PMoO9sGTQ/aTBsxEfzj/CLqAY84FJG3/03GBPbPcwt7pnVQaIc9bo8hoyVCMhNt0D5nN+ybQ0hznnQgn9Tw7Nw==
-  dependencies:
-    "@testing-library/dom" "^7.27.1"
-
-"@testing-library/user-event@^12.6.3":
-  version "12.6.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.6.3.tgz#4a77c56a48823cf8adebd0f57670e4a89c24d058"
-  integrity sha512-PCmbUKofE4SXA7l8jphZAbvv5H3c4ix34xPZ/GNe99fASX//msJRgiMbHIBP+GwRfgVG9c7zmkODSPu2X2vNRw==
+"@testing-library/user-event@^13.1.9":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
+  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
@@ -2348,6 +2361,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@*":
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.5.0.tgz#e04ed1824ca6b1dd0438997ba60f99a7405d4c7b"
+  integrity sha512-9RBFx7r4k+msyj/arpfaa0WOOEcaAZNmN+j80KFbFCoSqCJGHTz7YMAMGQW9Xmqm5w6l5c25vbSjMwlikJi5+g==
+  dependencies:
+    jest-matcher-utils "^27.0.0"
+    pretty-format "^27.0.0"
+
 "@types/jest@^26.0.0":
   version "26.0.20"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
@@ -2448,6 +2469,20 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
+"@types/react-dom@<18.0.0":
+  version "17.0.16"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.16.tgz#7caba93cf2806c51e64d620d8dff4bae57e06cc4"
+  integrity sha512-DWcXf8EbMrO/gWnQU7Z88Ws/p16qxGpPyjTKTpmBSFKeE+HveVubqGO1CVK7FrwlWD5MuOcvh8gtd0/XO38NdQ==
+  dependencies:
+    "@types/react" "^17"
+
+"@types/react-dom@>=16.9.0":
+  version "18.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.3.tgz#a022ea08c75a476fe5e96b675c3e673363853831"
+  integrity sha512-1RRW9kst+67gveJRYPxGmVy8eVJ05O43hg77G2j5m76/RFJtMbcfAs2viQ2UNsvvDg8F7OfQZx8qQcl6ymygaQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-dom@^16.9.10":
   version "16.9.10"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.10.tgz#4485b0bec3d41f856181b717f45fd7831101156f"
@@ -2499,6 +2534,13 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/react-test-renderer@>=16.9.0":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz#7b7f69ca98821ea5501b21ba24ea7b6139da2243"
+  integrity sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.0.tgz#882839db465df1320e4753e6e9f70ca7e9b4d46d"
@@ -2512,6 +2554,15 @@
   integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
   dependencies:
     "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@>=16.9.0":
+  version "18.0.8"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.8.tgz#a051eb380a9fbcaa404550543c58e1cf5ce4ab87"
+  integrity sha512-+j2hk9BzCOrrOSJASi5XiOyBbERk9jG5O73Ya4M0env5Ixi6vUNli4qy994AINcEF+1IEHISYFfIT4zwr++LKw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/react@^16":
@@ -2528,6 +2579,15 @@
   integrity sha512-zPrXn03hmPYqh9DznqSFQsoRtrQ4aHgnZDO+hMGvsE/PORvDTdJCHQ6XvJV31ic+0LzF73huPFXUb++W6Kri0Q==
   dependencies:
     "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17":
+  version "17.0.44"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.44.tgz#c3714bd34dd551ab20b8015d9d0dbec812a51ec7"
+  integrity sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/recompose@^0.30.7":
@@ -2556,6 +2616,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
+
 "@types/source-list-map@*":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
@@ -2570,6 +2635,13 @@
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
   integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.14.3"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.3.tgz#ee6c7ffe9f8595882ee7bda8af33ae7b8789ef17"
+  integrity sha512-oKZe+Mf4ioWlMuzVBaXQ9WDnEm1+umLx0InILg+yvZVBBDmzV5KfZyLrCvadtWcx8+916jLmHafcmqqffl+iIw==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/uglify-js@*":
   version "3.11.1"
@@ -3082,6 +3154,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -3100,6 +3177,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.2.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 ansicolors@~0.3.2:
   version "0.3.2"
@@ -3430,6 +3512,11 @@ aria-query@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
+
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arity-n@^1.0.4:
   version "1.0.4"
@@ -5324,6 +5411,11 @@ css-what@^4.0.0:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-4.0.0.tgz#35e73761cab2eeb3d3661126b23d7aa0e8432233"
   integrity sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
 css@2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.3.tgz#f861f4ba61e79bedc962aa548e5780fd95cbc6be"
@@ -5343,6 +5435,15 @@ css@^2.0.0:
     source-map "^0.6.1"
     source-map-resolve "^0.5.2"
     urix "^0.1.0"
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 cssdb@^4.4.0:
   version "4.4.0"
@@ -5724,6 +5825,11 @@ diff-sequences@^26.6.2:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
 
+diff-sequences@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
+  integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
+
 diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -5799,10 +5905,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
-  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
+dom-accessibility-api@^0.5.6, dom-accessibility-api@^0.5.9:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
+  integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -8802,6 +8908,16 @@ jest-diff@^26.0.0, jest-diff@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
+jest-diff@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
+  integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
+
 jest-docblock@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
@@ -8849,6 +8965,11 @@ jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
   integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
+
+jest-get-type@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
+  integrity sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==
 
 jest-haste-map@^26.6.2:
   version "26.6.2"
@@ -8912,6 +9033,16 @@ jest-matcher-utils@^26.6.0, jest-matcher-utils@^26.6.2:
     jest-diff "^26.6.2"
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
+
+jest-matcher-utils@^27.0.0:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz#9c0cdbda8245bc22d2331729d1091308b40cf8ab"
+  integrity sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
 
 jest-message-util@^26.6.0, jest-message-util@^26.6.2:
   version "26.6.2"
@@ -9970,6 +10101,11 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 mini-create-react-context@^0.4.0:
   version "0.4.1"
@@ -11847,6 +11983,15 @@ pretty-format@^26.0.0, pretty-format@^26.6.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
+pretty-format@^27.0.0, pretty-format@^27.0.2, pretty-format@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -12159,6 +12304,13 @@ react-dom@^16.14.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^6.0.9:
   version "6.0.9"
@@ -12567,6 +12719,14 @@ recursive-readdir@2.2.2:
   integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
   dependencies:
     minimatch "3.0.4"
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 redeyed@~2.1.0:
   version "2.1.1"
@@ -13524,6 +13684,14 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.1, source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
+
 source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
@@ -13929,6 +14097,13 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
VEN-1275. Show the GDPR -notes on every berth form wizard page (after step 2).

Step 3

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/389204/167081476-34c3ba48-6fd1-462b-89de-2407c4278e36.png">
<img width="943" alt="image" src="https://user-images.githubusercontent.com/389204/167081521-52591dc2-6607-4964-9b31-0d0346efa3c8.png">
<img width="927" alt="image" src="https://user-images.githubusercontent.com/389204/167081544-5267bea5-ac4a-4662-9e79-bd5a360bfc85.png">

Step 4

<img width="950" alt="image" src="https://user-images.githubusercontent.com/389204/167081604-8b9a0e93-c895-4ec6-8025-3463d6aa4f92.png">
<img width="928" alt="image" src="https://user-images.githubusercontent.com/389204/167081661-f96f220e-bc49-424f-99b4-9e7762398191.png">

Step 5

<img width="822" alt="image" src="https://user-images.githubusercontent.com/389204/167081784-b126e872-09e9-4c21-82a2-067f93e6c3ed.png">

<img width="535" alt="image" src="https://user-images.githubusercontent.com/389204/167081838-012fd8ca-2416-49ea-b9d2-daca78a6ede2.png">
