### PR TITLE
Allow lowercase letters on boat registration number but convert them to uppercase

### DIFF
--- a/src/common/registeredBoatDetails/RegisteredBoatDetails.tsx
+++ b/src/common/registeredBoatDetails/RegisteredBoatDetails.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Col, Row } from 'reactstrap';
+import { FormSpy } from 'react-final-form';
 
 import { mustBeBoatRegistrationNumber } from '../utils/formValidation';
 import { Text } from '../fields/Fields';
@@ -7,6 +8,7 @@ import { BoatType, WithBoatType } from '../selects/Selects';
 
 const RegisteredBoatDetails = ({ boatTypes }: WithBoatType) => {
   const { t } = useTranslation();
+
   return (
     <>
       <h3>{t('form.registered.header.title')}</h3>
@@ -20,6 +22,14 @@ const RegisteredBoatDetails = ({ boatTypes }: WithBoatType) => {
             placeholder="form.registered.field.register_number.placeholder"
             required
             validate={mustBeBoatRegistrationNumber}
+          />
+          <FormSpy
+            subscription={{ values: true }}
+            onChange={(props) => {
+              if (props.values.boatRegistrationNumber) {
+                props.values.boatRegistrationNumber = props.values.boatRegistrationNumber.toUpperCase();
+              }
+            }}
           />
         </Col>
         <Col sm={6}>

--- a/src/common/utils/formValidation.ts
+++ b/src/common/utils/formValidation.ts
@@ -153,7 +153,7 @@ export const mustBeBusinessId = (value: string): string | undefined => {
 };
 
 export const mustBeBoatRegistrationNumber = (value: string): string | undefined => {
-  const regex = /^[A-ZÄÖÅ][0-9]{1,10}$/;
+  const regex = /^[A-ZÄÖÅa-zöäå][0-9]{1,10}$/;
   if (regex.test(value)) {
     return undefined;
   }


### PR DESCRIPTION
## Description :sparkles:
This allows users to input both upper- and lowercase letters on boat registration number input, and automatically converts the input value to uppercase.

## Issues :bug:

### Closes :no_good_woman:
VEN-1529

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

