### PR TITLE
hide profile option from navigation

### DIFF
--- a/src/common/layout/navbar/Navbar.tsx
+++ b/src/common/layout/navbar/Navbar.tsx
@@ -76,10 +76,6 @@ const Navbar = ({ disableNav }: NavbarProps) => {
             onSignIn={() => authService.login(currentLocation)}
           >
             <Navigation.Item
-              label={t('site.navbar.profile')}
-              {...makeNavigationItemProps(localizedLink('/profile', language), history)}
-            />
-            <Navigation.Item
               label={t('site.navbar.log_out')}
               {...makeNavigationItemProps(localizedLink('/logout', language), history)}
             />


### PR DESCRIPTION
## Description :sparkles:
Hide "profile" tab for now from the navigation for now, since it's not complete yet. If it gets completed, profile can be added back. This is done so Venepaikat can be released from master while moving to Platta.

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

