### PR TITLE
Ven-1546: Hide trailer payment link

### DIFF
--- a/src/common/card/Card.tsx
+++ b/src/common/card/Card.tsx
@@ -8,6 +8,7 @@ type Props = {
   title: string;
   btnLabel: string;
   children: React.ReactNode;
+  buttonHidden?: boolean;
 };
 
 interface InternalProps extends Props {
@@ -36,16 +37,18 @@ const Card = (props: CardProps) => {
           {title}
         </CardTitle>
         <div className="vene-card__description">{children}</div>
-        <Button
-          className="vene-card__button"
-          type="button"
-          color="primary"
-          outline
-          {...(isInternal(props) ? rest : { ...rest, tag: 'a' })}
-        >
-          <span className="vene-card__button-label">{btnLabel}</span>
-          <Icon name={isInternal(props) ? 'arrowRight' : 'linkExternal'} className="vene-card__arrow-icon" />
-        </Button>
+        {!props.buttonHidden && (
+          <Button
+            className="vene-card__button"
+            type="button"
+            color="primary"
+            outline
+            {...(isInternal(props) ? rest : { ...rest, tag: 'a' })}
+          >
+            <span className="vene-card__button-label">{btnLabel}</span>
+            <Icon name={isInternal(props) ? 'arrowRight' : 'linkExternal'} className="vene-card__arrow-icon" />
+          </Button>
+        )}
       </CardBody>
     </RSCard>
   );

--- a/src/features/frontPage/FrontPage.tsx
+++ b/src/features/frontPage/FrontPage.tsx
@@ -89,6 +89,7 @@ const FrontPage = ({ localePush }: Props) => {
                 title={t('page.front.card.trailer.title')}
                 href={trailerPaymentURL.href}
                 rel="noopener noreferrer nofollow"
+                buttonHidden
               >
                 <p>{t('page.front.card.trailer.description')}</p>
               </Card>


### PR DESCRIPTION
## Description :sparkles:

Hide old trailer payment link from the frontpage for now.

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:
![Screenshot 2023-03-13 at 14 36 36](https://user-images.githubusercontent.com/53874567/224705545-0d28ed33-175e-4eb3-b776-3a6b8f1b4561.png)

## Additional notes :spiral_notepad:

