### PR TITLE
docs: add info how to fix SassError on "yarn start" on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ $ yarn start
 
 This will start [the application](http://localhost:3000) on port `3000`.
 
+### Problems starting development environment
+
+#### Windows specific
+
+- `SassError: File to import not found or unreadable`, e.g. `@import 'helsinki/colors';`
+  - Change all `:` characters to `;` in SASS_PATH, see [sass documentation](https://github.com/sass/sass/blob/embedded-protocol-2.1.0/js-api-doc/legacy/options.d.ts#L32-L35)
+
 ### Starting dockerized development environment
 
 1. Check if Docker and docker CLI installed, port `3000` and `9000` is free, not occupied by running server.


### PR DESCRIPTION
## Description :sparkles:

### docs: add info how to fix SassError on "yarn start" on Windows

refs VEN-1558 (noticed "yarn start" didn't work on Windows)

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

[VEN-1558](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1558)

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:



[VEN-1558]: https://helsinkisolutionoffice.atlassian.net/browse/VEN-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ