### PR TITLE
test: add robustness (remove env var dependency, use TZ in formatDate)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "prettier": "prettier",
     "start": "react-scripts start",
     "test": "cross-env TZ=UTC NODE_ICU_DATA=node_modules/full-icu react-scripts test --no-watch",
-    "test:ci": "cross-env TZ=UTC NODE_ICU_DATA=node_modules/full-icu CI=true && yarn test:coverage",
+    "test:ci": "cross-env TZ=UTC NODE_ICU_DATA=node_modules/full-icu CI=true react-scripts test --coverage",
     "test:coverage": "cross-env TZ=UTC NODE_ICU_DATA=node_modules/full-icu react-scripts test --coverage",
-    "test:watch": "react-scripts test",
+    "test:watch": "cross-env TZ=UTC NODE_ICU_DATA=node_modules/full-icu react-scripts test",
     "types:generate": "apollo client:codegen --target=typescript --globalTypesFile='src/__generated__/globalTypes.ts'"
   },
   "dependencies": {

--- a/src/app/auth/__tests__/__snapshots__/authService.test.ts.snap
+++ b/src/app/auth/__tests__/__snapshots__/authService.test.ts.snap
@@ -1,17 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`authService fetchApiTokens should call axios.get with the right arguments 1`] = `
-Array [
-  "api-tokens/",
-  Object {
-    "baseURL": "https://tunnistamo.test.hel.ninja",
-    "headers": Object {
-      "Authorization": "bearer db237bc3-e197-43de-8c86-3feea4c5f886",
-    },
-  },
-]
-`;
-
 exports[`authService fetchApiTokens should call localStorage.setItem with the right arguments 1`] = `
 Array [
   "apiTokens",

--- a/src/app/auth/__tests__/authService.test.ts
+++ b/src/app/auth/__tests__/authService.test.ts
@@ -77,12 +77,19 @@ describe('authService', () => {
     });
 
     it('should call axios.get with the right arguments', async () => {
-      expect.assertions(2);
+      expect.assertions(5);
 
       await authService.fetchApiTokens(mockUser);
 
-      expect(axios.get as MockedGet).toHaveBeenCalledTimes(1);
-      expect((axios.get as MockedGet).mock.calls[0]).toMatchSnapshot();
+      const mockedGet = axios.get as MockedGet;
+      expect(mockedGet).toHaveBeenCalledTimes(1);
+      expect(mockedGet.mock.calls).toHaveLength(1);
+      expect(mockedGet.mock.calls[0]).toHaveLength(2);
+      expect(mockedGet.mock.calls[0][0]).toStrictEqual('api-tokens/');
+      expect(mockedGet.mock.calls[0][1]).toStrictEqual({
+        baseURL: process.env.REACT_APP_TUNNISTAMO_URI,
+        headers: { Authorization: 'bearer db237bc3-e197-43de-8c86-3feea4c5f886' },
+      });
     });
 
     it('should call localStorage.setItem with the right arguments', async () => {

--- a/src/common/utils/format.ts
+++ b/src/common/utils/format.ts
@@ -31,7 +31,14 @@ export const formatDate = (date: string | null, locale: string, withTime = false
     hour: '2-digit',
     minute: '2-digit',
   };
-  const options = withTime ? { ...dateOpts, ...timeOpts } : dateOpts;
+  const optionalTimeZoneOpts = process.env.TZ ? { timeZone: process.env.TZ } : {};
+  const options = withTime
+    ? {
+        ...dateOpts,
+        ...timeOpts,
+        ...optionalTimeZoneOpts,
+      }
+    : dateOpts;
 
   return new Date(date).toLocaleString(locale, options);
 };


### PR DESCRIPTION
## Description :sparkles:

### test: add robustness (remove env var dependency, use TZ in formatDate)

package.json test running:
 - make "test:ci" work on its own without dependence on "test:coverage"
 - add environment variable settings to "test:watch"

tests:
 - fetchApiTokens > should call axios.get with the right arguments
   - This test case was dependent on REACT_APP_TUNNISTAMO_URI being set
	 to https://tunnistamo.test.hel.ninja in the environment
   - Removed the dependence by testing against the current value of the
	 REACT_APP_TUNNISTAMO_URI environment variable in the test
 - formatDate > should include time info when the third argument is true
   - This test case didn't work on Windows even with TZ=UTC environment
	 variable was set correctly during the test (Tried it on Windows)
   - Fixed on Windows also by using process.env.TZ as the timezone in
	 formatDate function if process.env.TZ is set

refs VEN-1558 (trying to get the tests pass locally on Windows)

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

[VEN-1558](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1558)

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:



[VEN-1558]: https://helsinkisolutionoffice.atlassian.net/browse/VEN-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ