### PR TITLE
VEN-1575 | Make formatPercentage support 0–3 fractional digits for e.g. 25,5%

### DIFF
--- a/src/common/utils/__tests__/format.test.ts
+++ b/src/common/utils/__tests__/format.test.ts
@@ -56,8 +56,43 @@ describe('format', () => {
       expect(formatPercentage(1, 'fi')).toMatch('%');
     });
 
-    it('should return the right value', () => {
-      expect(formatPercentage(10, 'fi')).toEqual('10 %');
+    // \u00A0 = No-Break Space (NBSP)
+    it.each<[number, string, string]>([
+      // Finnish
+      [0, 'fi', '0\u00A0%'],
+      [1, 'fi', '1\u00A0%'],
+      [1.23, 'fi', '1,23\u00A0%'],
+      [9, 'fi', '9\u00A0%'],
+      [12.3456789, 'fi', '12,346\u00A0%'],
+      [15, 'fi', '15\u00A0%'],
+      [24, 'fi', '24\u00A0%'],
+      [25.5, 'fi', '25,5\u00A0%'],
+      [31.26, 'fi', '31,26\u00A0%'],
+      [42.347, 'fi', '42,347\u00A0%'],
+      // Swedish
+      [0, 'sv', '0\u00A0%'],
+      [1, 'sv', '1\u00A0%'],
+      [1.23, 'sv', '1,23\u00A0%'],
+      [9, 'sv', '9\u00A0%'],
+      [12.3456789, 'sv', '12,346\u00A0%'],
+      [15, 'sv', '15\u00A0%'],
+      [24, 'sv', '24\u00A0%'],
+      [25.5, 'sv', '25,5\u00A0%'],
+      [31.26, 'sv', '31,26\u00A0%'],
+      [42.347, 'sv', '42,347\u00A0%'],
+      // English
+      [0, 'en', '0%'],
+      [1, 'en', '1%'],
+      [1.23, 'en', '1.23%'],
+      [9, 'en', '9%'],
+      [12.3456789, 'en', '12.346%'],
+      [15, 'en', '15%'],
+      [24, 'en', '24%'],
+      [25.5, 'en', '25.5%'],
+      [31.26, 'en', '31.26%'],
+      [42.347, 'en', '42.347%'],
+    ])('formatPercentage(%s, "%s") == "%s"', (value: number, locale: string, expectedResult: string) => {
+      expect(formatPercentage(value, locale)).toEqual(expectedResult);
     });
   });
 });

--- a/src/common/utils/format.ts
+++ b/src/common/utils/format.ts
@@ -56,8 +56,19 @@ export const formatPrice = (value: number, locale: string, percentage?: number) 
   return formatter.format(value);
 };
 
+/**
+ * Formats a number as a percentage in the given locale with 0–3 fraction digits.
+ * @param value The number to format as a percentage
+ * @param locale The locale to use for formatting ('fi', 'en' or 'sv')
+ * @returns The formatted percentage rounded to maximum of three fraction digits,
+ * with a decimal separator and grouping separator (if any) depending on locale,
+ * and a percentage sign.
+ * @example formatPercentage(25.5, 'en') == '25,5%'
+ */
 export const formatPercentage = (value: number, locale: string) => {
   return new Intl.NumberFormat(locale, {
     style: 'percent',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 3,
   }).format(value / 100);
 };


### PR DESCRIPTION
## Description :sparkles:

### feat: make formatPercentage support 0–3 fractional digits for e.g. 25,5%

e.g. previously formatPercentage(25.5, 'en') == '26%', now '25.5%'

also add more tests for formatPercentage

refs VEN-1575 (VAT percentage change to 25.5% as of 2024-09-01)

## Issues :bug:

[VEN-1575](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1575)

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:



[VEN-1575]: https://helsinkisolutionoffice.atlassian.net/browse/VEN-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ