### PR TITLE
VEN-1575 | fix(tests): use default 25.5% VAT in mock data

### DIFF
--- a/src/features/profile/berths/__fixtures__/mockData.ts
+++ b/src/features/profile/berths/__fixtures__/mockData.ts
@@ -59,7 +59,7 @@ export const mockOrder: Order = {
   price: 284,
   totalPrice: 440,
   vatAmount: 85.16,
-  vatPercentage: 24,
+  vatPercentage: 25.5,
 };
 
 export const mockPaidOrder: Order = {
@@ -117,7 +117,7 @@ export const mockPaidOrder: Order = {
   price: 284,
   totalPrice: 440,
   vatAmount: 85.16,
-  vatPercentage: 24,
+  vatPercentage: 25.5,
 };
 
 export const mockChoices: Choice<Properties>[] = [

--- a/src/features/profile/winterStorage/__fixtures__/mockData.ts
+++ b/src/features/profile/winterStorage/__fixtures__/mockData.ts
@@ -51,7 +51,7 @@ export const mockOrder: Order = {
   price: 284,
   totalPrice: 440,
   vatAmount: 85.16,
-  vatPercentage: 24,
+  vatPercentage: 25.5,
 };
 
 export const mockPaidOrder: Order = {
@@ -102,7 +102,7 @@ export const mockPaidOrder: Order = {
   price: 284,
   totalPrice: 440,
   vatAmount: 85.16,
-  vatPercentage: 24,
+  vatPercentage: 25.5,
 };
 
 export const mockChoices: Choice<Properties>[] = [


### PR DESCRIPTION
## Description :sparkles:

### fix(tests): use default 25.5% VAT in mock data

refs VEN-1575

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

[VEN-1575](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1575)

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

