### PR TITLE
VEN-1575 | fix: servicemap URLs so they always have locale

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -907,7 +907,7 @@
     "common": {
       "list": "List",
       "map": "On the map",
-      "servicemapURL": "https://servicemap.hel.fi/unit/{{servicemapId}}",
+      "servicemapURL": "https://servicemap.hel.fi/en/unit/{{servicemapId}}",
       "loading": "Loading"
     },
     "navbar": {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -911,7 +911,7 @@
     "common": {
       "list": "Lista",
       "map": "Kartalla",
-      "servicemapURL": "https://palvelukartta.hel.fi/unit/{{servicemapId}}",
+      "servicemapURL": "https://palvelukartta.hel.fi/fi/unit/{{servicemapId}}",
       "loading": "Ladataan"
     },
     "navbar": {

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -908,7 +908,7 @@
     "common": {
       "list": "Förteckning",
       "map": "På kartan",
-      "servicemapURL": "https://servicekarta.hel.fi/unit/{{servicemapId}}",
+      "servicemapURL": "https://servicekarta.hel.fi/sv/unit/{{servicemapId}}",
       "loading": "Laddar"
     },
     "navbar": {


### PR DESCRIPTION
## Description :sparkles:

### fix: servicemap URLs so they always have locale

differences between the different locale versions of palvelukartta:
- servicemap.hel.fi/unit/X redirects to servicemap.hel.fi/en/unit/X
- servicekarta.hel.fi/unit/X redirects -> servicekarta.hel.fi/sv/unit/X
- palvelukartta.hel.fi/unit/X DOES NOT redirect to
  palvelukartta.hel.fi/fi/unit/X and thus the URL works incorrectly

refs VEN-1575

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

[VEN-1575](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1575)

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:



[VEN-1575]: https://helsinkisolutionoffice.atlassian.net/browse/VEN-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ