### PR TITLE
feat: remove routes for summer services

### DIFF
--- a/browser-tests/frontPage.ts
+++ b/browser-tests/frontPage.ts
@@ -1,10 +1,9 @@
 import { footerSelectors } from './selectors/footer';
 import { frontPageSelectors } from './selectors/frontPage';
 import { navbarSelectors } from './selectors/navbar';
-import { navigateToFrontPage } from './utils/navigation';
 import { envUrl } from './utils/settings';
 import { switchToEnglish, switchToFinnish, switchToSwedish } from './utils/switchLanguage';
-import { isBerthsPage, isFrontPage } from './utils/page';
+import { isFrontPage } from './utils/page';
 
 fixture('Front page').page(envUrl());
 
@@ -30,15 +29,6 @@ test('Switching language', async (t) => {
   // Switch to Finnish
   await switchToFinnish(t);
   await t.expect(title.innerText).eql('Venepaikat');
-});
-
-test('Front page links', async (t) => {
-  const { berths } = frontPageSelectors;
-
-  // Berths
-  await t.click(berths);
-  await isBerthsPage();
-  await navigateToFrontPage();
 });
 
 test('Footer', async (t) => {

--- a/browser-tests/selectors/navbar.ts
+++ b/browser-tests/selectors/navbar.ts
@@ -5,7 +5,6 @@ const element = Selector('header');
 
 export const navbarSelectors = {
   mainLink: within(element).getByRole('link', { name: 'Venepaikat' }),
-  berths: within(element).getByText('Venepaikkahaku'),
   languageSelect: {
     button: within(element).getByRole('button', {
       name: /site\.language\.select/i,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,8 +4,6 @@ import { RouteComponentProps } from 'react-router-dom';
 
 import SwitchOfferCompletedPage from '../features/berthSwitchOffer/SwitchOfferCompletedPage';
 import ApplicationSentPage from '../features/notice/ApplicationSentPage';
-import BerthFormPageContainer from '../features/berth/berthFormPage/BerthFormPageContainer';
-import BerthPageContainer from '../features/berth/berthPage/BerthPageContainer';
 import BerthSwitchOfferPageContainer from '../features/berthSwitchOffer/BerthSwitchOfferPageContainer';
 import ProfilePageContainer from '../features/profile/ProfilePageContainer';
 import CallbackPage from './auth/callbackPage/CallbackPage';
@@ -19,9 +17,7 @@ import OrderCancelledPage from '../features/payment/cancelOrderPage/OrderCancell
 import PaymentPageContainer from '../features/payment/paymentPage/PaymentPageContainer';
 import PrivateRoute from './auth/privateRoute/PrivateRoute';
 import MockProfilePageContainer from '../features/profile/MockProfilePageContainer';
-import SelectedBerthPageContainer from '../features/berth/selectedBerthPage/SelectedBerthPageContainer';
 import i18n from '../locales/i18n';
-import { ApplicationType } from '../common/types/applicationType';
 import { LocaleOpts } from '../common/types/intl';
 import { PaymentResultContainer } from '../features/payment/paymentResultPage/PaymentResultContainer';
 import { isMockProfileRouteEnabled, isUserAuthenticationEnabled } from '../common/utils/featureFlags';
@@ -29,7 +25,6 @@ import { isMockProfileRouteEnabled, isUserAuthenticationEnabled } from '../commo
 type Props = RouteComponentProps<{ locale: LocaleOpts }>;
 
 const localeParam = ':locale(fi|en|sv)';
-const berthParam = `:app(${ApplicationType.BerthApp})`;
 
 const App = ({
   match: {
@@ -51,11 +46,6 @@ const App = ({
       {isMockProfileRouteEnabled && (
         <PrivateRoute exact path={`/${localeParam}/profile/:id`} component={MockProfilePageContainer} />
       )}
-
-      <Route exact path={`/${localeParam}/${berthParam}`} component={BerthPageContainer} />
-      <Route exact path={`/${localeParam}/${berthParam}/selected`} component={SelectedBerthPageContainer} />
-      <Route exact path={`/${localeParam}/${berthParam}/form`} component={BerthFormPageContainer} />
-      <Route exact path={`/${localeParam}/${berthParam}/form/:tab`} component={BerthFormPageContainer} />
 
       <Route exact path={`/${localeParam}/payment`} component={PaymentPageContainer} />
       <Route exact path={`/${localeParam}/payment-result`} component={PaymentResultContainer} />

--- a/src/common/hero/hero.scss
+++ b/src/common/hero/hero.scss
@@ -4,15 +4,7 @@
 .vene-hero {
   background-size: cover;
   background-position: right top;
-  padding: 4em 0;
-  min-height: 10em;
-  @include for-tablet {
-    min-height: 20em;
-  }
-  @include for-big-desktop {
-    min-height: 30em;
-  }
-
+  flex-grow: 1;
   &__title {
     font-size: 3em;
     hyphens: auto;

--- a/src/common/layout/navbar/Navbar.tsx
+++ b/src/common/layout/navbar/Navbar.tsx
@@ -7,7 +7,7 @@ import { useLocation } from 'react-router-dom';
 import authService from '../../../app/auth/authService';
 import { useCurrentUser } from '../../../app/auth/hooks';
 import { isUserAuthenticationEnabled } from '../../utils/featureFlags';
-import { isLinkActive, localizedLink, makeNavigationItemProps, stripUrlLocale } from './utils';
+import { localizedLink, makeNavigationItemProps, stripUrlLocale } from './utils';
 
 const Navbar = () => {
   const {
@@ -33,26 +33,9 @@ const Navbar = () => {
     titleUrl: localizedLink('/', language),
   };
   const languages = ['fi', 'sv', 'en'];
-  const links = [
-    {
-      url: '/berths',
-      label: t('site.berth.title'),
-    },
-  ];
 
   return (
     <Navigation {...navigationProps}>
-      <Navigation.Row>
-        {links.map(({ label, url }) => (
-          <Navigation.Item
-            key={url}
-            active={isLinkActive(localizedLink(url, language), location)}
-            {...makeNavigationItemProps(localizedLink(url, language), history)}
-            label={label}
-          />
-        ))}
-      </Navigation.Row>
-
       <Navigation.Actions>
         {isUserAuthenticationEnabled && (
           <Navigation.User

--- a/src/features/frontPage/FrontPage.tsx
+++ b/src/features/frontPage/FrontPage.tsx
@@ -1,12 +1,9 @@
 import { useLayoutEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RouteComponentProps } from 'react-router-dom';
-import { Container, Row, Col } from 'reactstrap';
 
 import { LocalePush, withMatchParamsHandlers } from '../../common/utils/container';
-import Card from '../../common/card/Card';
 import Hero from '../../common/hero/Hero';
-import KoroSection from '../../common/layout/koroSection/KoroSection';
 import Layout from '../../common/layout/Layout';
 import frontHeroImg from '../../assets/images/hero_image_front.jpg';
 
@@ -17,7 +14,7 @@ type Props = {
 } & RouteComponentProps;
 
 const FrontPage = ({ localePush }: Props) => {
-  const { t, i18n } = useTranslation();
+  const { i18n } = useTranslation();
   useLayoutEffect(() => window.scrollTo(0, 0), []);
 
   const trailerPaymentURL = new URL(process.env.REACT_APP_TRAILER_PAYMENT_URL ?? window.location.href);
@@ -26,42 +23,6 @@ const FrontPage = ({ localePush }: Props) => {
   return (
     <Layout>
       <Hero title="page.front.title" bgUrl={frontHeroImg} />
-      {/* The service is shutting down, so we are not using the title and description.
-      They are explicitly set as undefined, so the properties are easily seeable for devs, 
-      until we have a good fitting text to show there.
-      Ref. https://helsinkisolutionoffice.atlassian.net/browse/VEN-1596. */}
-      <KoroSection color="fog" top title={undefined} description={undefined} centered>
-        <Container className="vene-front-page">
-          <Row sm="1" md="2" lg="2">
-            <Col className="vene-front-page__card-wrapper">
-              <Card
-                onClick={() => localePush('/berths')}
-                btnLabel={t('page.front.card.berths.button_label')}
-                title={t('page.front.card.berths.title')}
-              >
-                <p>{t('page.front.card.berths.description')}</p>
-                <a
-                  href="https://www.hel.fi/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/veneily/vuokrattavat-venepaikat"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  <p>{t('page.front.card.instructions')}</p>
-                </a>
-              </Card>
-            </Col>
-            <Col className="vene-front-page__card-wrapper">
-              <Card
-                btnLabel={t('page.front.card.trailer.button_label')}
-                title={t('page.front.card.trailer.title')}
-                href={trailerPaymentURL.href}
-                rel="noopener noreferrer nofollow"
-              >
-                <p>{t('page.front.card.trailer.description')}</p>
-              </Card>
-            </Col>
-          </Row>
-        </Container>
-      </KoroSection>
     </Layout>
   );
 };


### PR DESCRIPTION
NOTE: this is alternative solution for https://github.com/City-of-Helsinki/berth-reservations-ui/pull/530

VEN-1604.

Remove all cards and berth links from front page: Remove the summer service cards from frontpage.

Remove front page koros section: Grow the hero over the empty koros space, so there is nothing in front page but hero and footer under the navbar.

Remove navbar navigation row: Remove the whole navigation row since the last link from the Navbar's navigation row is removed.

Remove berth routes from application router and browser-tests.

<img width="1790" alt="image" src="https://github.com/user-attachments/assets/8cef6302-687e-411d-8e37-443a945b8e81" />

<img width="402" alt="image" src="https://github.com/user-attachments/assets/96dfdfd5-10ea-4c2f-a3cf-ed5684a83ea4" />
